### PR TITLE
Add pathology article pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ pip install -r requirements.txt
 ## Pathology Article Retrieval
 
 The `pathology_pipeline` module helps curate pathology-related articles from
-PubMed Central. It searches terms between 2000 and 2023 using the Entrez API,
-downloads the corresponding XML files, and extracts article text.
+PubMed Central. It searches terms between 2000 and 2023 using the Entrez API
+and reports how many articles match before downloading. The XML files are then
+downloaded and parsed to extract article text.
 
 ```python
 from pathlib import Path
@@ -42,7 +43,7 @@ from pmc15_pipeline import pathology_pipeline
 
 keywords = ["pathology", "histopathology", "whole-slide image", "H&E"]
 
-# Search for PMCIDs
+# Search for PMCIDs. The number of matching articles will be printed.
 pmcids = pathology_pipeline.search_pmcids(keywords)
 
 # Download articles and extract text

--- a/README.md
+++ b/README.md
@@ -30,6 +30,29 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## Pathology Article Retrieval
+
+The `pathology_pipeline` module helps curate pathology-related articles from
+PubMed Central. It searches terms between 2000 and 2023 using the Entrez API,
+downloads the corresponding XML files, and extracts article text.
+
+```python
+from pathlib import Path
+from pmc15_pipeline import pathology_pipeline
+
+keywords = ["pathology", "histopathology", "whole-slide image", "H&E"]
+
+# Search for PMCIDs
+pmcids = pathology_pipeline.search_pmcids(keywords)
+
+# Download articles and extract text
+pathology_pipeline.download_articles(pmcids, Path("_results/pathology/xml"))
+pathology_pipeline.extract_article_text(
+    Path("_results/pathology/xml"),
+    Path("_results/pathology/articles.jsonl"),
+)
+```
+
 ## Reference
 ```bibtex
 @article{zhang2024biomedclip,

--- a/pmc15_pipeline/__init__.py
+++ b/pmc15_pipeline/__init__.py
@@ -1,6 +1,17 @@
 """BiomedCLIP data pipeline."""
 
-from . import data, pathology_pipeline
+from importlib import import_module
+
+from . import data
 
 __all__ = ["data", "pathology_pipeline"]
+
+
+def __getattr__(name):
+    """Lazily import submodules when accessed."""
+    if name == "pathology_pipeline":
+        module = import_module(".pathology_pipeline", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/pmc15_pipeline/__init__.py
+++ b/pmc15_pipeline/__init__.py
@@ -1,0 +1,6 @@
+"""BiomedCLIP data pipeline."""
+
+from . import data, pathology_pipeline
+
+__all__ = ["data", "pathology_pipeline"]
+

--- a/pmc15_pipeline/pathology_pipeline.py
+++ b/pmc15_pipeline/pathology_pipeline.py
@@ -68,6 +68,8 @@ def search_pmcids(
             handle.close()
             pmcids.update(batch.get("IdList", []))
 
+    print(f"Found {len(pmcids)} pathology articles")
+
     return pmcids
 
 
@@ -98,7 +100,10 @@ def download_articles(
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    for pmcid in tqdm(list(pmcids)):
+    pmcid_list = list(pmcids)
+    print(f"Preparing to download {len(pmcid_list)} pathology articles")
+
+    for pmcid in tqdm(pmcid_list):
         file_path = output_dir / f"{pmcid}.nxml"
         if file_path.exists():
             continue

--- a/pmc15_pipeline/pathology_pipeline.py
+++ b/pmc15_pipeline/pathology_pipeline.py
@@ -1,0 +1,139 @@
+"""Utilities for curating pathology-related articles from PubMed Central."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Optional, Set
+
+from Bio import Entrez
+from tqdm import tqdm
+
+import pubmed_parser
+
+
+DEFAULT_EMAIL = "your.email@example.com"
+
+
+def search_pmcids(
+    terms: Iterable[str],
+    *,
+    email: str = DEFAULT_EMAIL,
+    api_key: Optional[str] = None,
+    start_year: int = 2000,
+    end_year: int = 2023,
+) -> Set[str]:
+    """Search PubMed Central for a list of terms.
+
+    Parameters
+    ----------
+    terms:
+        Search terms to query. Each term is searched individually.
+    email:
+        Email address for NCBI Entrez registration.
+    api_key:
+        Optional NCBI API key for higher rate limits.
+    start_year:
+        Earliest publication year.
+    end_year:
+        Latest publication year.
+
+    Returns
+    -------
+    Set[str]
+        A set of unique PMCIDs returned by the search.
+    """
+
+    Entrez.email = email
+    if api_key:
+        Entrez.api_key = api_key
+
+    pmcids: Set[str] = set()
+
+    for term in terms:
+        query = f"{term} AND ({start_year}[PDAT] : {end_year}[PDAT])"
+        handle = Entrez.esearch(db="pmc", term=query, retmax=0)
+        record = Entrez.read(handle)
+        handle.close()
+        count = int(record["Count"])
+
+        for start in range(0, count, 1000):
+            handle = Entrez.esearch(
+                db="pmc",
+                term=query,
+                retmax=1000,
+                retstart=start,
+            )
+            batch = Entrez.read(handle)
+            handle.close()
+            pmcids.update(batch.get("IdList", []))
+
+    return pmcids
+
+
+def download_articles(
+    pmcids: Iterable[str],
+    output_dir: Path,
+    *,
+    email: str = DEFAULT_EMAIL,
+    api_key: Optional[str] = None,
+) -> None:
+    """Download full articles from PubMed Central by PMCID.
+
+    Parameters
+    ----------
+    pmcids:
+        PMCIDs of articles to download.
+    output_dir:
+        Directory to store downloaded XML files.
+    email:
+        Email for Entrez.
+    api_key:
+        Optional API key.
+    """
+
+    Entrez.email = email
+    if api_key:
+        Entrez.api_key = api_key
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for pmcid in tqdm(list(pmcids)):
+        file_path = output_dir / f"{pmcid}.nxml"
+        if file_path.exists():
+            continue
+        handle = Entrez.efetch(db="pmc", id=pmcid, rettype="full", retmode="xml")
+        data = handle.read()
+        handle.close()
+        with open(file_path, "w", encoding="utf8") as f:
+            f.write(data)
+
+
+def extract_article_text(
+    article_dir: Path, output_file: Path
+) -> None:
+    """Parse downloaded articles and write JSONL of article texts.
+
+    Parameters
+    ----------
+    article_dir:
+        Folder containing downloaded ``.nxml`` files.
+    output_file:
+        Output JSONL file path.
+    """
+
+    with output_file.open("w", encoding="utf8") as out_f:
+        for nxml_path in tqdm(sorted(article_dir.glob("*.nxml"))):
+            parsed = pubmed_parser.parse_pubmed_xml(str(nxml_path), nxml=True)
+            text_parts: List[str] = [
+                parsed.get("full_title", ""),
+                parsed.get("abstract", ""),
+            ]
+            article_text = "\n".join(part for part in text_parts if part)
+            out = {
+                "pmcid": parsed.get("pmc", nxml_path.stem),
+                "pmid": parsed.get("pmid", ""),
+                "text": article_text,
+            }
+            out_f.write(json.dumps(out) + "\n")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ ipykernel
 ipython
 matplotlib
 opencv-python==4.8.0.74
-PILLOW
+biopython
+Pillow
 pytest
 requests
 rich==10.12.0


### PR DESCRIPTION
## Summary
- implement `pathology_pipeline` with utilities to query PubMed Central via Entrez and download articles
- add module export in `pmc15_pipeline/__init__.py`
- document pathology article retrieval in README
- add `biopython` dependency and update requirements

## Testing
- `python -m py_compile pmc15_pipeline/pathology_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_b_6889d8ef89848327b32a6c59406f04df