### PR TITLE
Add keyword-based article counting utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,30 +34,30 @@ pip install -r requirements.txt
 
 `generate_pmc15_pipeline_outputs` can restrict the dataset to figures whose
 captions mention specific terms. By default it keeps only captions containing
-"pathology", "whole slide image", "H&E", "x-ray", "MRI", "endoscopy",
-"gastrology", or "ultrasound":
+these domain keywords and labels each figure with the matched domain(s):
+
+- **pathology:** "pathology", "whole slide image", "H&E"
+- **x-ray:** "x-ray"
+- **endoscopy:** "endoscopy", "gastrology"
+- **ultra:** "ultrasound"
+- **mri:** "MRI"
+
+Each figure written to `pubmed_parsed_data.json` includes a `domains` array, and
+the enclosing article lists all domains found across its figures.
 
 ```python
 from pmc15_pipeline.data import generate_pmc15_pipeline_outputs
 
-generate_pmc15_pipeline_outputs(
-    keywords=[
-        "pathology",
-        "whole slide image",
-        "H&E",
-        "x-ray",
-        "MRI",
-        "endoscopy",
-        "gastrology",
-        "ultrasound",
-    ]
-)
+generate_pmc15_pipeline_outputs()  # Use defaults shown above
+
+# Or provide your own list of keywords
+# generate_pmc15_pipeline_outputs(keywords=["custom term"])
 ```
 
-## Counting Articles by Keyword
+## Counting Articles by Domain
 
-After generating `pubmed_parsed_data.json`, you can count how many articles
-mention specific topics in their figure captions:
+After generating `pubmed_parsed_data.json`, you can see how many articles
+mention each domain in their figure captions:
 
 ```python
 from pmc15_pipeline.data import count_articles_with_keywords
@@ -66,7 +66,7 @@ count_articles_with_keywords()
 ```
 
 Provide your own list of terms with the `keywords` argument if you want to
-search for different phrases.
+search for different phrases instead of the preset domains.
 
 ## Reference
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -34,12 +34,24 @@ pip install -r requirements.txt
 
 `generate_pmc15_pipeline_outputs` can restrict the dataset to figures whose
 captions mention specific terms. By default it keeps only captions containing
-"pathology", "whole slide image", or "H&E":
+"pathology", "whole slide image", "H&E", "x-ray", "MRI", "endoscopy",
+"gastrology", or "ultrasound":
 
 ```python
 from pmc15_pipeline.data import generate_pmc15_pipeline_outputs
 
-generate_pmc15_pipeline_outputs(keywords=["pathology", "whole slide image", "H&E"])
+generate_pmc15_pipeline_outputs(
+    keywords=[
+        "pathology",
+        "whole slide image",
+        "H&E",
+        "x-ray",
+        "MRI",
+        "endoscopy",
+        "gastrology",
+        "ultrasound",
+    ]
+)
 ```
 
 ## Counting Articles by Keyword

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ from pmc15_pipeline.data import (
 download_pubmed_file_list()
 download_pubmed_files_from_list(subset_size=100)  # streamed in chunks
 decompress_pubmed_files()  # skips archives already extracted and continues past errors
+generate_pmc15_pipeline_outputs()  # streams captions to keep memory usage low
 ```
 
 ## Filtering Captions by Keyword

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ also writes `_results/data/domain_caption_pairs.jsonl`, containing one line per
 figure-domain combination with the structure `{ "domain": "pathology", "text": "caption" }`.
 Figures lacking any of the keywords are skipped entirely, so a small sample of
 articles may yield an empty output file if none of their captions mention the
-default terms.
+default terms. Captions containing common animal terms (for example “mouse” or
+“rat”) are omitted to focus on human-related content. Set
+`exclude_keywords=None` to include them.
 You can also fetch domain keyword mappings from remote JSON glossaries by
 providing a `glossary_urls` dictionary. Each key is a domain name and each value
 is a URL returning a JSON array of keywords for that domain. Passing a single
@@ -61,6 +63,9 @@ generate_pmc15_pipeline_outputs()  # Use defaults shown above
 
 # Or provide your own list of keywords
 # generate_pmc15_pipeline_outputs(keywords=["custom term"])
+
+# Include captions mentioning animals
+# generate_pmc15_pipeline_outputs(exclude_keywords=None)
 
 # Pull domain keywords from remote glossaries
 # generate_pmc15_pipeline_outputs(

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Each figure written to `pubmed_parsed_data.json` includes a `domains` array, and
 the enclosing article lists all domains found across its figures. The function
 also writes `_results/data/domain_caption_pairs.jsonl`, containing one line per
 figure-domain combination with the structure `{ "domain": "pathology", "text": "caption" }`.
+Figures lacking any of the keywords are skipped entirely, so a small sample of
+articles may yield an empty output file if none of their captions mention the
+default terms.
 You can also fetch domain keyword mappings from remote JSON glossaries by
 providing a `glossary_urls` dictionary. Each key is a domain name and each value
 is a URL returning a JSON array of keywords for that domain. Passing a single

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## Filtering Captions by Keyword
+
+`generate_pmc15_pipeline_outputs` can restrict the dataset to figures whose
+captions mention specific terms. By default it keeps only captions containing
+"pathology", "whole slide image", or "H&E":
+
+```python
+from pmc15_pipeline.data import generate_pmc15_pipeline_outputs
+
+generate_pmc15_pipeline_outputs(keywords=["pathology", "whole slide image", "H&E"])
+```
+
 ## Counting Articles by Keyword
 
 After generating `pubmed_parsed_data.json`, you can count how many articles

--- a/README.md
+++ b/README.md
@@ -34,14 +34,7 @@ pip install -r requirements.txt
 
 `generate_pmc15_pipeline_outputs` can restrict the dataset to figures whose
 captions mention specific terms. By default it keeps only captions containing
-these keywords:
-
-- "pathology"
-- "whole slide image"
-- "H&E"
-
-Figures that pass this filter are still annotated with imaging domains. The
-default domain mapping is:
+keywords from these imaging domains:
 
 - **pathology:** "pathology", "whole slide image", "H&E"
 - **x-ray:** "x-ray"
@@ -114,7 +107,7 @@ export_domain_caption_pairs()
 ## Exporting Captions with Default Keywords
 
 If you already have `pubmed_parsed_data.json` but only want the captions that
-mention the default pathology keywords, create a lightweight JSONL file:
+mention the default imaging-domain keywords, create a lightweight JSONL file:
 
 ```python
 from pmc15_pipeline.data import export_keyword_caption_pairs

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## Counting Articles by Keyword
+
+After generating `pubmed_parsed_data.json`, you can count how many articles
+mention specific topics in their figure captions:
+
+```python
+from pmc15_pipeline.data import count_articles_with_keywords
+
+count_articles_with_keywords()
+```
+
+Provide your own list of terms with the `keywords` argument if you want to
+search for different phrases.
+
 ## Reference
 ```bibtex
 @article{zhang2024biomedclip,

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Each figure written to `pubmed_parsed_data.json` includes a `domains` array, and
 the enclosing article lists all domains found across its figures. The function
 also writes `_results/data/domain_caption_pairs.jsonl`, containing one line per
 figure-domain combination with the structure `{ "domain": "pathology", "text": "caption" }`.
-You can also fetch the domain keyword mapping from a remote JSON glossary by
-passing its URL with `glossary_url`.
+You can also fetch domain keyword mappings from remote JSON glossaries by
+providing a `glossary_urls` dictionary. Each key is a domain name and each value
+is a URL returning a JSON array of keywords for that domain. Passing a single
+URL is still supported for backward compatibility.
 
 ```python
 from pmc15_pipeline.data import generate_pmc15_pipeline_outputs
@@ -57,8 +59,13 @@ generate_pmc15_pipeline_outputs()  # Use defaults shown above
 # Or provide your own list of keywords
 # generate_pmc15_pipeline_outputs(keywords=["custom term"])
 
-# Pull domain keywords from a remote glossary
-# generate_pmc15_pipeline_outputs(glossary_url="https://example.com/domain_glossary.json")
+# Pull domain keywords from remote glossaries
+# generate_pmc15_pipeline_outputs(
+#     glossary_urls={
+#         "pathology": "https://example.com/pathology_keywords.json",
+#         "mri": "https://example.com/mri_keywords.json",
+#     }
+# )
 ```
 
 ## Counting Articles by Domain
@@ -71,8 +78,13 @@ from pmc15_pipeline.data import count_articles_with_keywords
 
 count_articles_with_keywords()
 
-# Use the same remote glossary as above
-# count_articles_with_keywords(glossary_url="https://example.com/domain_glossary.json")
+# Use the same remote glossaries as above
+# count_articles_with_keywords(
+#     glossary_urls={
+#         "pathology": "https://example.com/pathology_keywords.json",
+#         "mri": "https://example.com/mri_keywords.json",
+#     }
+# )
 ```
 
 Provide your own list of terms with the `keywords` argument if you want to

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ from pmc15_pipeline.data import (
 )
 
 download_pubmed_file_list()
-download_pubmed_files_from_list(subset_size=100)  # adjust as needed
+download_pubmed_files_from_list(subset_size=100)  # streamed in chunks
 decompress_pubmed_files()  # skips archives already extracted and continues past errors
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ count_articles_with_keywords()
 Provide your own list of terms with the `keywords` argument if you want to
 search for different phrases instead of the preset domains.
 
+## Exporting Domain-Caption Pairs
+
+To create a lightweight dataset for domain classification, write one line per
+figure with its domain and caption text:
+
+```python
+from pmc15_pipeline.data import export_domain_caption_pairs
+
+export_domain_caption_pairs()
+```
+
+This produces `_results/data/domain_caption_pairs.jsonl` where each line is a
+JSON object of the form `{ "domain": "pathology", "text": "caption" }`.
+
 ## Reference
 ```bibtex
 @article{zhang2024biomedclip,

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ decompress_pubmed_files()  # skips archives already extracted and continues past
 generate_pmc15_pipeline_outputs()  # streams captions to keep memory usage low
 ```
 
+## Processing in Batches
+
+Large datasets can overwhelm memory and disk if processed all at once. Run the
+entire pipeline in batches of 5,000 archives (or any size you choose) and append
+results to `pubmed_parsed_data.json`:
+
+```python
+from pmc15_pipeline.data import process_in_batches
+
+process_in_batches(batch_size=5000)
+
+# Resume from a particular offset in the file list
+# process_in_batches(batch_size=5000, start_index=10000)
+```
+
+Previously downloaded or extracted archives are skipped, so re-running the
+function continues where it left off without reprocessing earlier files.
+
 ## Filtering Captions by Keyword
 
 `generate_pmc15_pipeline_outputs` can restrict the dataset to figures whose

--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ pip install -r requirements.txt
 
 `generate_pmc15_pipeline_outputs` can restrict the dataset to figures whose
 captions mention specific terms. By default it keeps only captions containing
-these domain keywords and labels each figure with the matched domain(s):
+these keywords:
+
+- "pathology"
+- "whole slide image"
+- "H&E"
+
+Figures that pass this filter are still annotated with imaging domains. The
+default domain mapping is:
 
 - **pathology:** "pathology", "whole slide image", "H&E"
 - **x-ray:** "x-ray"
@@ -103,6 +110,21 @@ from pmc15_pipeline.data import export_domain_caption_pairs
 
 export_domain_caption_pairs()
 ```
+
+## Exporting Captions with Default Keywords
+
+If you already have `pubmed_parsed_data.json` but only want the captions that
+mention the default pathology keywords, create a lightweight JSONL file:
+
+```python
+from pmc15_pipeline.data import export_keyword_caption_pairs
+
+export_keyword_caption_pairs()
+```
+
+Each line in `_results/data/keyword_caption_pairs.jsonl` has the form
+`{ "text": "caption" }`. Pass your own list of `keywords` to filter for
+different terms.
 
 ## Reference
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ these domain keywords and labels each figure with the matched domain(s):
 - **mri:** "MRI"
 
 Each figure written to `pubmed_parsed_data.json` includes a `domains` array, and
-the enclosing article lists all domains found across its figures.
+the enclosing article lists all domains found across its figures. The function
+also writes `_results/data/domain_caption_pairs.jsonl`, containing one line per
+figure-domain combination with the structure `{ "domain": "pathology", "text": "caption" }`.
 You can also fetch the domain keyword mapping from a remote JSON glossary by
 passing its URL with `glossary_url`.
 
@@ -81,14 +83,14 @@ search for different phrases instead of the preset domains.
 To create a lightweight dataset for domain classification, write one line per
 figure with its domain and caption text:
 
+`generate_pmc15_pipeline_outputs` writes this file automatically; if you need
+to recreate it from an existing dataset, call:
+
 ```python
 from pmc15_pipeline.data import export_domain_caption_pairs
 
 export_domain_caption_pairs()
 ```
-
-This produces `_results/data/domain_caption_pairs.jsonl` where each line is a
-JSON object of the form `{ "domain": "pathology", "text": "caption" }`.
 
 ## Reference
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## Downloading and Decompressing Articles
+
+```python
+from pmc15_pipeline.data import (
+    download_pubmed_file_list,
+    download_pubmed_files_from_list,
+    decompress_pubmed_files,
+)
+
+download_pubmed_file_list()
+download_pubmed_files_from_list(subset_size=100)  # adjust as needed
+decompress_pubmed_files()  # skips archives already extracted and continues past errors
+```
+
 ## Filtering Captions by Keyword
 
 `generate_pmc15_pipeline_outputs` can restrict the dataset to figures whose

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ these domain keywords and labels each figure with the matched domain(s):
 
 Each figure written to `pubmed_parsed_data.json` includes a `domains` array, and
 the enclosing article lists all domains found across its figures.
+You can also fetch the domain keyword mapping from a remote JSON glossary by
+passing its URL with `glossary_url`.
 
 ```python
 from pmc15_pipeline.data import generate_pmc15_pipeline_outputs
@@ -52,6 +54,9 @@ generate_pmc15_pipeline_outputs()  # Use defaults shown above
 
 # Or provide your own list of keywords
 # generate_pmc15_pipeline_outputs(keywords=["custom term"])
+
+# Pull domain keywords from a remote glossary
+# generate_pmc15_pipeline_outputs(glossary_url="https://example.com/domain_glossary.json")
 ```
 
 ## Counting Articles by Domain
@@ -63,6 +68,9 @@ mention each domain in their figure captions:
 from pmc15_pipeline.data import count_articles_with_keywords
 
 count_articles_with_keywords()
+
+# Use the same remote glossary as above
+# count_articles_with_keywords(glossary_url="https://example.com/domain_glossary.json")
 ```
 
 Provide your own list of terms with the `keywords` argument if you want to

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -32,6 +32,42 @@ DEFAULT_KEYWORDS = [
     kw for kws in DEFAULT_DOMAIN_KEYWORDS.values() for kw in kws
 ]
 
+# Common animal-related terms that should be excluded to focus on human data
+ANIMAL_KEYWORDS = [
+    "mouse",
+    "mice",
+    "murine",
+    "rat",
+    "rats",
+    "rabbit",
+    "rabbits",
+    "canine",
+    "dog",
+    "dogs",
+    "cat",
+    "cats",
+    "feline",
+    "porcine",
+    "pig",
+    "pigs",
+    "swine",
+    "bovine",
+    "cow",
+    "cattle",
+    "sheep",
+    "goat",
+    "hamster",
+    "monkey",
+    "monkeys",
+    "primate",
+    "primates",
+    "zebrafish",
+    "drosophila",
+    "fruit fly",
+    "guinea pig",
+    "ferret",
+]
+
 
 def load_domain_keywords(urls: dict[str, str] | str | None = None) -> dict[str, list[str]]:
     """Load domain keywords from remote ``urls`` or fall back to defaults.
@@ -241,6 +277,7 @@ def generate_pmc15_pipeline_outputs(
     ),
     keywords: list[str] | None = None,
     glossary_urls: dict[str, str] | str | None = None,
+    exclude_keywords: list[str] | None = ANIMAL_KEYWORDS,
     domain_caption_output: Path | None = (
         repo_root / "_results" / "data" / "domain_caption_pairs.jsonl"
     ),
@@ -255,6 +292,7 @@ def generate_pmc15_pipeline_outputs(
 
     domain_keywords = load_domain_keywords(glossary_urls)
     keywords_lower = {kw.lower() for kw in (keywords or DEFAULT_KEYWORDS)}
+    exclude_lower = [kw.lower() for kw in (exclude_keywords or [])]
     domain_keywords_lower = {
         domain: [kw.lower() for kw in kws]
         for domain, kws in domain_keywords.items()
@@ -311,6 +349,8 @@ def generate_pmc15_pipeline_outputs(
 
                 caption = str(figure_dict.get("fig_caption", ""))
                 caption_lower = caption.lower()
+                if exclude_lower and any(kw in caption_lower for kw in exclude_lower):
+                    continue
                 if not any(kw in caption_lower for kw in keywords_lower):
                     continue
 

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -25,8 +25,12 @@ DEFAULT_DOMAIN_KEYWORDS = {
     "mri": ["MRI"],
 }
 
-# Only captions containing these keywords are retained by default.
-DEFAULT_KEYWORDS = DEFAULT_DOMAIN_KEYWORDS["pathology"]
+# Only captions containing these keywords are retained by default. This list
+# combines all domain keywords so the default dataset includes figures from any
+# supported imaging modality.
+DEFAULT_KEYWORDS = [
+    kw for kws in DEFAULT_DOMAIN_KEYWORDS.values() for kw in kws
+]
 
 
 def load_domain_keywords(urls: dict[str, str] | str | None = None) -> dict[str, list[str]]:

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -13,7 +13,16 @@ from .types import PubMedFile
 from .utils import fs_utils
 
 repo_root = fs_utils.get_repo_root_path()
-DEFAULT_KEYWORDS = ["pathology", "whole slide image", "H&E"]
+DEFAULT_KEYWORDS = [
+    "pathology",
+    "whole slide image",
+    "H&E",
+    "x-ray",
+    "MRI",
+    "endoscopy",
+    "gastrology",
+    "ultrasound",
+]
 
 
 def download_pubmed_file_list(

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -13,6 +13,7 @@ from .types import PubMedFile
 from .utils import fs_utils
 
 repo_root = fs_utils.get_repo_root_path()
+DEFAULT_KEYWORDS = ["pathology", "whole slide image", "H&E"]
 
 
 def download_pubmed_file_list(
@@ -174,10 +175,13 @@ def generate_pmc15_pipeline_outputs(
     output_file_path: Path = (
         repo_root / "_results" / "data" / "pubmed_parsed_data.json"
     ),
+    keywords: list[str] | None = None,
 ):
 
     # input - path to .nxml file for each article in the article package
     # output - json object with pmid, pmc id, location (path to article package in storage blobs), figures - list of figure objects which include inline references (mentions of figure throughout the article), caption for the figure, id, label, graphic_ref (filepath to figure jpg in storage blobs), pair_id (a unique id to identify each figure in the article, using pmid + figure_id)
+    keywords_lower = [kw.lower() for kw in (keywords or DEFAULT_KEYWORDS)]
+
     def parse_single_pubmed_file(nxml_path: Path):
         print(nxml_path)
 
@@ -227,8 +231,12 @@ def generate_pmc15_pipeline_outputs(
                 if len(ir_objects) > 0:
                     raise NotImplementedError("Inline references not implemented")
 
+                caption = str(figure_dict.get("fig_caption", ""))
+                if not any(kw in caption.lower() for kw in keywords_lower):
+                    continue
+
                 figure_object = {
-                    "fig_caption": str(figure_dict.get("fig_caption", "")),
+                    "fig_caption": caption,
                     "fig_id": str(figure_dict.get("fig_id", "")),
                     "fig_label": str(figure_dict.get("fig_label", "")),
                     "graphic_ref": (
@@ -241,6 +249,9 @@ def generate_pmc15_pipeline_outputs(
                 }
 
                 figures.append(figure_object)
+
+            if not figures:
+                return []
 
             article = {
                 "pmid": pmid,
@@ -280,7 +291,7 @@ def count_articles_with_keywords(
     """
 
     if keywords is None:
-        keywords = ["pathology", "whole slide image", "H&E"]
+        keywords = DEFAULT_KEYWORDS
 
     keyword_counts = {kw.lower(): 0 for kw in keywords}
 

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -116,6 +116,51 @@ DOMAIN_KEYWORDS_LOWER = {
 }
 
 
+def _basic_caption_parse(nxml_path: Path) -> list[dict]:
+    """Fallback parser for figure captions when ``pubmed_parser`` fails.
+
+    This routine performs a lightweight XML walk to collect figure metadata
+    such as caption text, IDs and graphic references. It mirrors the minimal
+    structure returned by :func:`pubmed_parser.parse_pubmed_caption` so the
+    rest of the pipeline can proceed. Any errors result in an empty list.
+    """
+
+    try:
+        tree = etree.parse(str(nxml_path))
+    except Exception as err:  # pragma: no cover - parse errors are rare
+        print(f"Fallback parser failed for {nxml_path}: {err}")
+        return []
+
+    pmid = tree.findtext('.//article-id[@pub-id-type="pmid"]', default='')
+    pmc = tree.findtext('.//article-id[@pub-id-type="pmcid"]', default='')
+    figures: list[dict] = []
+
+    for fig in tree.findall('.//fig'):
+        caption_el = fig.find('caption')
+        caption_text = (
+            ''.join(caption_el.itertext()).strip() if caption_el is not None else ''
+        )
+        label = fig.findtext('label', default='')
+        graphic_el = fig.find('.//graphic')
+        graphic_ref = ''
+        if graphic_el is not None:
+            graphic_ref = graphic_el.get('{http://www.w3.org/1999/xlink}href', '')
+
+        figures.append(
+            {
+                'fig_caption': caption_text,
+                'fig_id': fig.get('id', ''),
+                'fig_label': label or '',
+                'graphic_ref': graphic_ref,
+                'pmid': pmid,
+                'pmc': pmc,
+                'fig_refs': [],
+            }
+        )
+
+    return figures
+
+
 def download_pubmed_file_list(
     url=PUBMED_OPEN_ACCESS_FILE_LIST_URL,
     output_file_path: Path = (
@@ -309,15 +354,11 @@ def generate_pmc15_pipeline_outputs(
             print("starting...")
             output = pubmed_parser.parse_pubmed_caption(str(nxml_path.absolute()))
             print("parsed", nxml_path)
-        except AttributeError as ae:
-            print("Attribute Error: " + str(ae) + " path: " + str(nxml_path))
-            return []
-        except etree.XMLSyntaxError as xmle:
-            print("XML Syntax Error: " + str(xmle) + " path: " + str(nxml_path))
-            return []
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - network/parsing errors
             print("Exception: " + str(e) + " path: " + str(nxml_path))
-            return []
+            output = _basic_caption_parse(nxml_path)
+            if not output:
+                return []
 
         if not output:
             print("no output")

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -3,6 +3,7 @@ import tarfile
 from pathlib import Path
 from typing import Optional
 import contextlib
+import gc
 
 import pubmed_parser
 import requests
@@ -117,46 +118,68 @@ DOMAIN_KEYWORDS_LOWER = {
 
 
 def _basic_caption_parse(nxml_path: Path) -> list[dict]:
-    """Fallback parser for figure captions when ``pubmed_parser`` fails.
+    """Memory-friendly caption parser using ``iterparse``.
 
-    This routine performs a lightweight XML walk to collect figure metadata
-    such as caption text, IDs and graphic references. It mirrors the minimal
-    structure returned by :func:`pubmed_parser.parse_pubmed_caption` so the
-    rest of the pipeline can proceed. Any errors result in an empty list.
+    ``pubmed_parser`` loads the entire XML tree into memory which can exceed
+    the container limits for articles embedding large images.  This streaming
+    parser walks the file incrementally and clears elements as soon as they
+    are processed, keeping the memory footprint small.  Only minimal figure
+    metadata is extracted.  Any errors result in an empty list.
     """
 
+    figures: list[dict] = []
+    pmid = ""
+    pmc = ""
+    current: dict | None = None
+
     try:
-        tree = etree.parse(str(nxml_path))
+        # ``huge_tree`` allows lxml to handle base64 encoded images without
+        # exhausting memory; ``iterparse`` ensures elements are discarded as we
+        # progress through the document.
+        context = etree.iterparse(
+            str(nxml_path), events=("start", "end"), recover=True, huge_tree=True
+        )
     except Exception as err:  # pragma: no cover - parse errors are rare
         print(f"Fallback parser failed for {nxml_path}: {err}")
         return []
 
-    pmid = tree.findtext('.//article-id[@pub-id-type="pmid"]', default='')
-    pmc = tree.findtext('.//article-id[@pub-id-type="pmcid"]', default='')
-    figures: list[dict] = []
-
-    for fig in tree.findall('.//fig'):
-        caption_el = fig.find('caption')
-        caption_text = (
-            ''.join(caption_el.itertext()).strip() if caption_el is not None else ''
-        )
-        label = fig.findtext('label', default='')
-        graphic_el = fig.find('.//graphic')
-        graphic_ref = ''
-        if graphic_el is not None:
-            graphic_ref = graphic_el.get('{http://www.w3.org/1999/xlink}href', '')
-
-        figures.append(
-            {
-                'fig_caption': caption_text,
-                'fig_id': fig.get('id', ''),
-                'fig_label': label or '',
-                'graphic_ref': graphic_ref,
-                'pmid': pmid,
-                'pmc': pmc,
-                'fig_refs': [],
+    for event, elem in context:
+        if event == "start" and elem.tag == "fig":
+            current = {
+                "fig_caption": "",
+                "fig_id": elem.get("id", ""),
+                "fig_label": "",
+                "graphic_ref": "",
+                "pmid": "",
+                "pmc": "",
+                "fig_refs": [],
             }
-        )
+        elif event == "end":
+            if elem.tag == "article-id":
+                id_type = elem.get("pub-id-type")
+                if id_type == "pmid":
+                    pmid = elem.text or ""
+                elif id_type == "pmcid":
+                    pmc = elem.text or ""
+            elif current is not None:
+                if elem.tag == "label":
+                    current["fig_label"] = elem.text or ""
+                elif elem.tag == "caption":
+                    current["fig_caption"] = "".join(elem.itertext()).strip()
+                elif elem.tag == "graphic":
+                    current["graphic_ref"] = elem.get(
+                        "{http://www.w3.org/1999/xlink}href", ""
+                    )
+                elif elem.tag == "fig":
+                    current["pmid"] = pmid
+                    current["pmc"] = pmc
+                    figures.append(current)
+                    current = None
+            # Release memory for processed elements
+            if elem.getparent() is not None:
+                while elem.getprevious() is not None:
+                    del elem.getparent()[0]
+                elem.clear()
 
     return figures
 
@@ -352,8 +375,22 @@ def generate_pmc15_pipeline_outputs(
 
         try:
             print("starting...")
-            output = pubmed_parser.parse_pubmed_caption(str(nxml_path.absolute()))
+            if nxml_path.stat().st_size > 5_000_000:
+                # Large XML files often embed images and may exhaust memory
+                output = _basic_caption_parse(nxml_path)
+            else:
+                output = pubmed_parser.parse_pubmed_caption(
+                    str(nxml_path.absolute())
+                )
+            if not output:
+                output = _basic_caption_parse(nxml_path)
             print("parsed", nxml_path)
+        except MemoryError:
+            # OOM while using pubmed_parser; retry with streaming parser
+            print("MemoryError: falling back to lightweight parser")
+            output = _basic_caption_parse(nxml_path)
+            if not output:
+                return []
         except Exception as e:  # pragma: no cover - network/parsing errors
             print("Exception: " + str(e) + " path: " + str(nxml_path))
             output = _basic_caption_parse(nxml_path)
@@ -453,7 +490,7 @@ def generate_pmc15_pipeline_outputs(
                             )
 
                 f.write(json.dumps(article) + "\n")
-
+            gc.collect()
     print(f"Processed {processed_files} files")
 
 

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -14,13 +14,42 @@ from .utils import fs_utils
 
 repo_root = fs_utils.get_repo_root_path()
 
-DOMAIN_KEYWORDS = {
+# Default set of domain keywords; these act as a fallback if a glossary
+# cannot be fetched from a remote source.
+DEFAULT_DOMAIN_KEYWORDS = {
     "pathology": ["pathology", "whole slide image", "H&E"],
     "x-ray": ["x-ray"],
     "endoscopy": ["endoscopy", "gastrology"],
     "ultra": ["ultrasound"],
     "mri": ["MRI"],
 }
+
+
+def load_domain_keywords(url: str | None = None) -> dict[str, list[str]]:
+    """Load domain keywords from ``url`` or fall back to defaults.
+
+    ``url`` should point to a JSON object mapping domain names to a list of
+    keywords. If the download fails or the mapping is incomplete, the
+    hard-coded defaults are used instead.
+    """
+
+    keywords = DEFAULT_DOMAIN_KEYWORDS.copy()
+
+    if url:
+        try:
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            for domain in keywords:
+                if isinstance(data.get(domain), list):
+                    keywords[domain] = data[domain]
+        except requests.RequestException as err:  # pragma: no cover - network
+            print(f"Failed to fetch domain glossary from {url}: {err}")
+
+    return keywords
+
+
+DOMAIN_KEYWORDS = load_domain_keywords()
 DEFAULT_KEYWORDS = [kw for kws in DOMAIN_KEYWORDS.values() for kw in kws]
 DOMAIN_KEYWORDS_LOWER = {
     domain: [kw.lower() for kw in keywords]
@@ -188,11 +217,19 @@ def generate_pmc15_pipeline_outputs(
         repo_root / "_results" / "data" / "pubmed_parsed_data.json"
     ),
     keywords: list[str] | None = None,
+    glossary_url: str | None = None,
 ):
 
     # input - path to .nxml file for each article in the article package
     # output - json object with pmid, pmc id, location (path to article package in storage blobs), figures - list of figure objects which include inline references (mentions of figure throughout the article), caption for the figure, id, label, graphic_ref (filepath to figure jpg in storage blobs), pair_id (a unique id to identify each figure in the article, using pmid + figure_id)
-    keywords_lower = [kw.lower() for kw in (keywords or DEFAULT_KEYWORDS)]
+    domain_keywords = load_domain_keywords(glossary_url)
+    keywords_lower = [
+        kw.lower() for kw in (keywords or [kw for kws in domain_keywords.values() for kw in kws])
+    ]
+    domain_keywords_lower = {
+        domain: [kw.lower() for kw in kws]
+        for domain, kws in domain_keywords.items()
+    }
 
     def parse_single_pubmed_file(nxml_path: Path):
         print(nxml_path)
@@ -250,7 +287,7 @@ def generate_pmc15_pipeline_outputs(
 
                 domains = [
                     domain
-                    for domain, kws in DOMAIN_KEYWORDS_LOWER.items()
+                    for domain, kws in domain_keywords_lower.items()
                     if any(kw in caption_lower for kw in kws)
                 ]
                 if not domains:
@@ -302,14 +339,15 @@ def generate_pmc15_pipeline_outputs(
 def count_articles_with_keywords(
     dataset_path: Path = repo_root / "_results" / "data" / "pubmed_parsed_data.json",
     keywords: list[str] | None = None,
-    domain_keywords: dict[str, list[str]] | None = DOMAIN_KEYWORDS,
+    domain_keywords: dict[str, list[str]] | None = None,
+    glossary_url: str | None = None,
 ) -> dict[str, int]:
     """Count articles whose figure captions mention given keywords or domains."""
 
     if keywords is not None:
         keyword_counts = {kw.lower(): 0 for kw in keywords}
     else:
-        domain_keywords = domain_keywords or DOMAIN_KEYWORDS
+        domain_keywords = domain_keywords or load_domain_keywords(glossary_url)
         domain_keywords_lower = {
             domain: [kw.lower() for kw in kws]
             for domain, kws in domain_keywords.items()

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -373,8 +373,9 @@ def generate_pmc15_pipeline_outputs(
             print("error")
             return []
 
+        print("starting...")
+        output: list[dict] = []
         try:
-            print("starting...")
             if nxml_path.stat().st_size > 5_000_000:
                 # Large XML files often embed images and may exhaust memory
                 output = _basic_caption_parse(nxml_path)
@@ -384,46 +385,48 @@ def generate_pmc15_pipeline_outputs(
                 )
             if not output:
                 output = _basic_caption_parse(nxml_path)
-            print("parsed", nxml_path)
         except MemoryError:
             # OOM while using pubmed_parser; retry with streaming parser
             print("MemoryError: falling back to lightweight parser")
             output = _basic_caption_parse(nxml_path)
-            if not output:
-                return []
-        except Exception as e:  # pragma: no cover - network/parsing errors
-            print("Exception: " + str(e) + " path: " + str(nxml_path))
+        except UnboundLocalError as err:
+            # Some articles trigger a bug in pubmed_parser referencing an
+            # undefined 'caption' variable.  Fall back to the lightweight parser
+            # without treating it as a fatal error.
+            print(f"Parser bug in pubmed_parser for {nxml_path}: {err}")
             output = _basic_caption_parse(nxml_path)
-            if not output:
-                return []
+        except Exception as err:  # pragma: no cover - unexpected parse errors
+            print(f"Error parsing {nxml_path}: {err}")
+            output = _basic_caption_parse(nxml_path)
 
         if not output:
             print("no output")
             return []
 
-        else:
-            figures = []
-            pmid = output[0]["pmid"]  # same for all figures in the article
-            pmc = output[0]["pmc"]  # same for all figures in the article
-            location = Path(nxml_path).parent
+        print("parsed", nxml_path)
 
-            # for all figures in the article, create a figure object with inline references (text, section, reference_id), and caption, id, label, graphic_ref, pair_id
-            for figure_dict in output:
-                inline_references = figure_dict.get(
-                    "fig_refs", {}
-                )  # from pubmed parser
-                ir_objects = []
-                for inline_reference in inline_references:
-                    inline_reference_object = {
-                        "text": str(inline_reference.get("text", "")),
-                        "section": str(inline_reference.get("section", "")),
-                        "reference_id": str(inline_reference.get("reference_id", "")),
-                    }
+        figures = []
+        pmid = output[0]["pmid"]  # same for all figures in the article
+        pmc = output[0]["pmc"]  # same for all figures in the article
+        location = Path(nxml_path).parent
 
-                    ir_objects.append(inline_reference_object)
+        # for all figures in the article, create a figure object with inline references (text, section, reference_id), and caption, id, label, graphic_ref, pair_id
+        for figure_dict in output:
+            inline_references = figure_dict.get(
+                "fig_refs", {}
+            )  # from pubmed parser
+            ir_objects = []
+            for inline_reference in inline_references:
+                inline_reference_object = {
+                    "text": str(inline_reference.get("text", "")),
+                    "section": str(inline_reference.get("section", "")),
+                    "reference_id": str(inline_reference.get("reference_id", "")),
+                }
 
-                if len(ir_objects) > 0:
-                    raise NotImplementedError("Inline references not implemented")
+                ir_objects.append(inline_reference_object)
+
+            if len(ir_objects) > 0:
+                raise NotImplementedError("Inline references not implemented")
 
                 caption = str(figure_dict.get("fig_caption", ""))
                 caption_lower = caption.lower()

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -335,3 +335,30 @@ def count_articles_with_keywords(
 
     print("Article counts:", keyword_counts)
     return keyword_counts
+
+
+def export_domain_caption_pairs(
+    dataset_path: Path = repo_root / "_results" / "data" / "pubmed_parsed_data.json",
+    output_path: Path = repo_root
+    / "_results"
+    / "data"
+    / "domain_caption_pairs.jsonl",
+) -> None:
+    """Write ``{"domain": d, "text": caption}`` pairs for each figure.
+
+    One line is written for every domain assigned to a figure in
+    ``dataset_path``. Figures with multiple domains will produce multiple
+    entries with the same caption.
+    """
+
+    with dataset_path.open("r") as src, output_path.open("w") as dest:
+        for line in src:
+            if not line.strip():
+                continue
+            article = json.loads(line)
+            for figure in article.get("figures", []):
+                caption = figure.get("fig_caption", "")
+                for domain in figure.get("domains", []):
+                    dest.write(
+                        json.dumps({"domain": domain, "text": caption}) + "\n"
+                    )

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -263,3 +263,38 @@ def generate_pmc15_pipeline_outputs(
                 f.write(json.dumps(article) + "\n")
 
     print(f"Processed {idx+1} files")
+
+
+def count_articles_with_keywords(
+    dataset_path: Path = repo_root / "_results" / "data" / "pubmed_parsed_data.json",
+    keywords: list[str] | None = None,
+) -> dict[str, int]:
+    """Count articles whose figure captions mention given keywords.
+
+    Args:
+        dataset_path: Path to the JSONL file produced by the pipeline.
+        keywords: List of case-insensitive keywords to search for.
+
+    Returns:
+        Dictionary mapping each keyword to the number of matching articles.
+    """
+
+    if keywords is None:
+        keywords = ["pathology", "whole slide image", "H&E"]
+
+    keyword_counts = {kw.lower(): 0 for kw in keywords}
+
+    with dataset_path.open("r") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            article = json.loads(line)
+            captions = " ".join(
+                fig.get("fig_caption", "") for fig in article.get("figures", [])
+            ).lower()
+            for kw in keyword_counts:
+                if kw in captions:
+                    keyword_counts[kw] += 1
+
+    print("Article counts:", keyword_counts)
+    return keyword_counts

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -162,20 +162,22 @@ def download_pubmed_files_from_list(
         python3 -m data.download_pubmed_files
     """
 
-    # Get dicts from files list
-    pubmed_files: list[PubMedFile] = []
+    output_folder_path.mkdir(parents=True, exist_ok=True)
+    skipped_files = []
+
+    def _get_file_size(url: str) -> int | None:
+        response = requests.head(url)
+        if "Content-Length" in response.headers:
+            return int(response.headers["Content-Length"])
+        return None
 
     with open(file_list_path, "r") as file:
-        lines = file.readlines()
-
-        # Skip header
-        lines = lines[1:]
-
-        for line_idx, line in enumerate(lines):
-            if subset_size and line_idx + 1 > subset_size:
+        next(file)  # skip header line
+        for line_idx, line in enumerate(file):
+            if subset_size and line_idx >= subset_size:
                 break
 
-            [path, title, pmcid, pmid, code] = line.strip().split("\t")
+            path, title, pmcid, pmid, code = line.strip().split("\t")
             pubmed_file: PubMedFile = {
                 "path": path,
                 "title": title,
@@ -183,50 +185,38 @@ def download_pubmed_files_from_list(
                 "pmid": pmid,
                 "code": code,
             }
-            pubmed_files.append(pubmed_file)
 
-    # Create output folder
-    output_folder_path.mkdir(parents=True, exist_ok=True)
-    skipped_files = []
+            file_name = pmcid + file_extension
+            file_path = output_folder_path / file_name
 
-    def _get_file_size(url):
-        response = requests.head(url)
-        if "Content-Length" in response.headers:
-            return int(response.headers["Content-Length"])
-        else:
-            return None
+            if file_path.exists():
+                tqdm.write(
+                    f"File: {file_name} already exists. Not downloading again."
+                )
+                continue
 
-    for pubmed_file in tqdm(pubmed_files):
-        file_name = pubmed_file["pmcid"] + file_extension
-        file_path = output_folder_path / file_name
+            article_url = PUBMED_OPEN_ACCESS_BASE_URL + path
+            file_size = _get_file_size(article_url)
+            if file_size is None:
+                tqdm.write(
+                    f"File: {file_name} Skipped! Could not get file size!"
+                )
+                skipped_files.append(pubmed_file)
+                continue
 
-        # Check if the file already exists
-        if file_path.exists():
-            tqdm.write(f"File: {file_name} already exists. Not downloading again.")
-            continue
-
-        article_url = PUBMED_OPEN_ACCESS_BASE_URL + pubmed_file["path"]
-        file_size = _get_file_size(article_url)
-
-        if file_size is not None:
             tqdm.write(f"File: {file_name} size: {file_size} bytes")
             try:
-                response = requests.get(article_url)
-                response.raise_for_status()  # Raise an HTTPError for bad responses
-
-                with open(file_path, "wb") as file:
-                    file.write(response.content)
-
-            except requests.exceptions.RequestException as e:
-                tqdm.write(f"File: {file_name} Skipped! Error occurred: {e}")
+                with requests.get(article_url, stream=True, timeout=30) as r:
+                    r.raise_for_status()
+                    with open(file_path, "wb") as f_out:
+                        for chunk in r.iter_content(chunk_size=8192):
+                            if chunk:
+                                f_out.write(chunk)
+            except requests.RequestException as e:
+                tqdm.write(
+                    f"File: {file_name} Skipped! Error occurred: {e}"
+                )
                 skipped_files.append(pubmed_file)
-
-            with open(file_path, "wb") as file:
-                file.write(response.content)
-
-        else:
-            tqdm.write(f"File: {file_name} Skipped! Could not get file size!")
-            skipped_files.append(pubmed_file)
 
     print(f"Skipped {len(skipped_files)} files.")
 

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -2,6 +2,7 @@ import json
 import tarfile
 from pathlib import Path
 from typing import Optional
+import contextlib
 
 import pubmed_parser
 import requests
@@ -218,6 +219,9 @@ def generate_pmc15_pipeline_outputs(
     ),
     keywords: list[str] | None = None,
     glossary_url: str | None = None,
+    domain_caption_output: Path | None = (
+        repo_root / "_results" / "data" / "domain_caption_pairs.jsonl"
+    ),
 ):
 
     # input - path to .nxml file for each article in the article package
@@ -322,7 +326,9 @@ def generate_pmc15_pipeline_outputs(
 
             return [article]
 
-    with output_file_path.open("w+") as f:
+    with output_file_path.open("w+") as f, (
+        domain_caption_output.open("w") if domain_caption_output else contextlib.nullcontext()
+    ) as cap_f:
         for idx, nxml_file in enumerate(decompressed_folder.rglob("*.nxml")):
             parsed = parse_single_pubmed_file(nxml_file)
 
@@ -330,6 +336,13 @@ def generate_pmc15_pipeline_outputs(
                 for figure in article["figures"]:
                     # remove inline references since we're not using them
                     figure.pop("inline_references")
+                    if cap_f:
+                        caption = figure.get("fig_caption", "")
+                        for domain in figure.get("domains", []):
+                            cap_f.write(
+                                json.dumps({"domain": domain, "text": caption})
+                                + "\n"
+                            )
 
                 f.write(json.dumps(article) + "\n")
 

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -252,7 +252,9 @@ def decompress_pubmed_files(
         python3 -m data.decompress_pubmed_files
     """
 
-    # Get dicts from files list
+    # Ensure output directory exists
+    output_folder_path.mkdir(parents=True, exist_ok=True)
+
     file_paths = list(input_folder_path.glob(file_extension))
 
     print(
@@ -260,10 +262,18 @@ def decompress_pubmed_files(
     )
 
     for file_path in tqdm(file_paths):
-        with tarfile.open(file_path, "r:gz") as tar_file:
-            # TODO: Use article folder path instead of output folder path?
-            # Causes duplicate folder names since tar file contains folder
-            tar_file.extractall(output_folder_path)
+        dest_dir = output_folder_path / file_path.name.replace(".tar.gz", "")
+
+        if dest_dir.exists():
+            tqdm.write(
+                f"Archive {file_path.name} already extracted. Skipping.")
+            continue
+
+        try:
+            with tarfile.open(file_path, "r:gz") as tar_file:
+                tar_file.extractall(output_folder_path)
+        except (tarfile.TarError, OSError) as err:
+            tqdm.write(f"Failed to extract {file_path.name}: {err}")
 
     print(f"Finished extracting {len(file_paths)} files")
 

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -25,6 +25,9 @@ DEFAULT_DOMAIN_KEYWORDS = {
     "mri": ["MRI"],
 }
 
+# Only captions containing these keywords are retained by default.
+DEFAULT_KEYWORDS = DEFAULT_DOMAIN_KEYWORDS["pathology"]
+
 
 def load_domain_keywords(urls: dict[str, str] | str | None = None) -> dict[str, list[str]]:
     """Load domain keywords from remote ``urls`` or fall back to defaults.
@@ -67,7 +70,6 @@ def load_domain_keywords(urls: dict[str, str] | str | None = None) -> dict[str, 
 
 
 DOMAIN_KEYWORDS = load_domain_keywords()
-DEFAULT_KEYWORDS = [kw for kws in DOMAIN_KEYWORDS.values() for kw in kws]
 DOMAIN_KEYWORDS_LOWER = {
     domain: [kw.lower() for kw in keywords]
     for domain, keywords in DOMAIN_KEYWORDS.items()
@@ -243,9 +245,7 @@ def generate_pmc15_pipeline_outputs(
     # input - path to .nxml file for each article in the article package
     # output - json object with pmid, pmc id, location (path to article package in storage blobs), figures - list of figure objects which include inline references (mentions of figure throughout the article), caption for the figure, id, label, graphic_ref (filepath to figure jpg in storage blobs), pair_id (a unique id to identify each figure in the article, using pmid + figure_id)
     domain_keywords = load_domain_keywords(glossary_urls)
-    keywords_lower = [
-        kw.lower() for kw in (keywords or [kw for kws in domain_keywords.values() for kw in kws])
-    ]
+    keywords_lower = [kw.lower() for kw in (keywords or DEFAULT_KEYWORDS)]
     domain_keywords_lower = {
         domain: [kw.lower() for kw in kws]
         for domain, kws in domain_keywords.items()
@@ -429,3 +429,30 @@ def export_domain_caption_pairs(
                     dest.write(
                         json.dumps({"domain": domain, "text": caption}) + "\n"
                     )
+
+
+def export_keyword_caption_pairs(
+    dataset_path: Path = repo_root / "_results" / "data" / "pubmed_parsed_data.json",
+    output_path: Path = repo_root
+    / "_results"
+    / "data"
+    / "keyword_caption_pairs.jsonl",
+    keywords: list[str] | None = None,
+) -> None:
+    """Write captions containing ``keywords`` to ``output_path``.
+
+    Each line of the resulting JSONL file has the structure
+    ``{"text": "caption"}``. ``keywords`` defaults to ``DEFAULT_KEYWORDS``.
+    """
+
+    keywords_lower = [kw.lower() for kw in (keywords or DEFAULT_KEYWORDS)]
+
+    with dataset_path.open("r") as src, output_path.open("w") as dest:
+        for line in src:
+            if not line.strip():
+                continue
+            article = json.loads(line)
+            for figure in article.get("figures", []):
+                caption = figure.get("fig_caption", "")
+                if any(kw in caption.lower() for kw in keywords_lower):
+                    dest.write(json.dumps({"text": caption}) + "\n")

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -13,16 +13,19 @@ from .types import PubMedFile
 from .utils import fs_utils
 
 repo_root = fs_utils.get_repo_root_path()
-DEFAULT_KEYWORDS = [
-    "pathology",
-    "whole slide image",
-    "H&E",
-    "x-ray",
-    "MRI",
-    "endoscopy",
-    "gastrology",
-    "ultrasound",
-]
+
+DOMAIN_KEYWORDS = {
+    "pathology": ["pathology", "whole slide image", "H&E"],
+    "x-ray": ["x-ray"],
+    "endoscopy": ["endoscopy", "gastrology"],
+    "ultra": ["ultrasound"],
+    "mri": ["MRI"],
+}
+DEFAULT_KEYWORDS = [kw for kws in DOMAIN_KEYWORDS.values() for kw in kws]
+DOMAIN_KEYWORDS_LOWER = {
+    domain: [kw.lower() for kw in keywords]
+    for domain, keywords in DOMAIN_KEYWORDS.items()
+}
 
 
 def download_pubmed_file_list(
@@ -241,7 +244,16 @@ def generate_pmc15_pipeline_outputs(
                     raise NotImplementedError("Inline references not implemented")
 
                 caption = str(figure_dict.get("fig_caption", ""))
-                if not any(kw in caption.lower() for kw in keywords_lower):
+                caption_lower = caption.lower()
+                if not any(kw in caption_lower for kw in keywords_lower):
+                    continue
+
+                domains = [
+                    domain
+                    for domain, kws in DOMAIN_KEYWORDS_LOWER.items()
+                    if any(kw in caption_lower for kw in kws)
+                ]
+                if not domains:
                     continue
 
                 figure_object = {
@@ -255,6 +267,7 @@ def generate_pmc15_pipeline_outputs(
                     ),  # set this to the path of the jpg image in storage blobs
                     "pair_id": str(pmid) + "_" + str(figure_dict.get("fig_id", "")),
                     "inline_references": ir_objects,  # add inline references
+                    "domains": domains,
                 }
 
                 figures.append(figure_object)
@@ -267,6 +280,7 @@ def generate_pmc15_pipeline_outputs(
                 "pmc": pmc,
                 "location": str(location),
                 "figures": figures,
+                "domains": sorted({d for fig in figures for d in fig["domains"]}),
             }
 
             return [article]
@@ -288,21 +302,19 @@ def generate_pmc15_pipeline_outputs(
 def count_articles_with_keywords(
     dataset_path: Path = repo_root / "_results" / "data" / "pubmed_parsed_data.json",
     keywords: list[str] | None = None,
+    domain_keywords: dict[str, list[str]] | None = DOMAIN_KEYWORDS,
 ) -> dict[str, int]:
-    """Count articles whose figure captions mention given keywords.
+    """Count articles whose figure captions mention given keywords or domains."""
 
-    Args:
-        dataset_path: Path to the JSONL file produced by the pipeline.
-        keywords: List of case-insensitive keywords to search for.
-
-    Returns:
-        Dictionary mapping each keyword to the number of matching articles.
-    """
-
-    if keywords is None:
-        keywords = DEFAULT_KEYWORDS
-
-    keyword_counts = {kw.lower(): 0 for kw in keywords}
+    if keywords is not None:
+        keyword_counts = {kw.lower(): 0 for kw in keywords}
+    else:
+        domain_keywords = domain_keywords or DOMAIN_KEYWORDS
+        domain_keywords_lower = {
+            domain: [kw.lower() for kw in kws]
+            for domain, kws in domain_keywords.items()
+        }
+        keyword_counts = {domain: 0 for domain in domain_keywords}
 
     with dataset_path.open("r") as f:
         for line in f:
@@ -312,9 +324,14 @@ def count_articles_with_keywords(
             captions = " ".join(
                 fig.get("fig_caption", "") for fig in article.get("figures", [])
             ).lower()
-            for kw in keyword_counts:
-                if kw in captions:
-                    keyword_counts[kw] += 1
+            if keywords is not None:
+                for kw in keyword_counts:
+                    if kw in captions:
+                        keyword_counts[kw] += 1
+            else:
+                for domain, kws in domain_keywords_lower.items():
+                    if any(kw in captions for kw in kws):
+                        keyword_counts[domain] += 1
 
     print("Article counts:", keyword_counts)
     return keyword_counts

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -26,26 +26,42 @@ DEFAULT_DOMAIN_KEYWORDS = {
 }
 
 
-def load_domain_keywords(url: str | None = None) -> dict[str, list[str]]:
-    """Load domain keywords from ``url`` or fall back to defaults.
+def load_domain_keywords(urls: dict[str, str] | str | None = None) -> dict[str, list[str]]:
+    """Load domain keywords from remote ``urls`` or fall back to defaults.
 
-    ``url`` should point to a JSON object mapping domain names to a list of
-    keywords. If the download fails or the mapping is incomplete, the
-    hard-coded defaults are used instead.
+    ``urls`` may be a single URL pointing to a JSON object mapping domain names
+    to lists of keywords, or a dictionary mapping individual domain names to
+    URLs returning a JSON array for that domain. Failed downloads leave the
+    default keywords in place.
     """
 
     keywords = DEFAULT_DOMAIN_KEYWORDS.copy()
 
-    if url:
+    if isinstance(urls, str) and urls:
+        # Backwards compatibility: single URL hosting all domains
         try:
-            response = requests.get(url, timeout=10)
+            response = requests.get(urls, timeout=10)
             response.raise_for_status()
             data = response.json()
             for domain in keywords:
                 if isinstance(data.get(domain), list):
                     keywords[domain] = data[domain]
         except requests.RequestException as err:  # pragma: no cover - network
-            print(f"Failed to fetch domain glossary from {url}: {err}")
+            print(f"Failed to fetch domain glossary from {urls}: {err}")
+    elif isinstance(urls, dict):
+        for domain, url in urls.items():
+            try:
+                response = requests.get(url, timeout=10)
+                response.raise_for_status()
+                data = response.json()
+                if isinstance(data, list):
+                    keywords[domain] = data
+                elif isinstance(data, dict) and isinstance(data.get(domain), list):
+                    keywords[domain] = data[domain]
+            except requests.RequestException as err:  # pragma: no cover - network
+                print(
+                    f"Failed to fetch domain glossary for '{domain}' from {url}: {err}"
+                )
 
     return keywords
 
@@ -218,7 +234,7 @@ def generate_pmc15_pipeline_outputs(
         repo_root / "_results" / "data" / "pubmed_parsed_data.json"
     ),
     keywords: list[str] | None = None,
-    glossary_url: str | None = None,
+    glossary_urls: dict[str, str] | str | None = None,
     domain_caption_output: Path | None = (
         repo_root / "_results" / "data" / "domain_caption_pairs.jsonl"
     ),
@@ -226,7 +242,7 @@ def generate_pmc15_pipeline_outputs(
 
     # input - path to .nxml file for each article in the article package
     # output - json object with pmid, pmc id, location (path to article package in storage blobs), figures - list of figure objects which include inline references (mentions of figure throughout the article), caption for the figure, id, label, graphic_ref (filepath to figure jpg in storage blobs), pair_id (a unique id to identify each figure in the article, using pmid + figure_id)
-    domain_keywords = load_domain_keywords(glossary_url)
+    domain_keywords = load_domain_keywords(glossary_urls)
     keywords_lower = [
         kw.lower() for kw in (keywords or [kw for kws in domain_keywords.values() for kw in kws])
     ]
@@ -353,14 +369,14 @@ def count_articles_with_keywords(
     dataset_path: Path = repo_root / "_results" / "data" / "pubmed_parsed_data.json",
     keywords: list[str] | None = None,
     domain_keywords: dict[str, list[str]] | None = None,
-    glossary_url: str | None = None,
+    glossary_urls: dict[str, str] | str | None = None,
 ) -> dict[str, int]:
     """Count articles whose figure captions mention given keywords or domains."""
 
     if keywords is not None:
         keyword_counts = {kw.lower(): 0 for kw in keywords}
     else:
-        domain_keywords = domain_keywords or load_domain_keywords(glossary_url)
+        domain_keywords = domain_keywords or load_domain_keywords(glossary_urls)
         domain_keywords_lower = {
             domain: [kw.lower() for kw in kws]
             for domain, kws in domain_keywords.items()

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -248,8 +248,13 @@ def generate_pmc15_pipeline_outputs(
 
     # input - path to .nxml file for each article in the article package
     # output - json object with pmid, pmc id, location (path to article package in storage blobs), figures - list of figure objects which include inline references (mentions of figure throughout the article), caption for the figure, id, label, graphic_ref (filepath to figure jpg in storage blobs), pair_id (a unique id to identify each figure in the article, using pmid + figure_id)
+    # Ensure destination directories exist before any processing occurs
+    output_file_path.parent.mkdir(parents=True, exist_ok=True)
+    if domain_caption_output:
+        Path(domain_caption_output).parent.mkdir(parents=True, exist_ok=True)
+
     domain_keywords = load_domain_keywords(glossary_urls)
-    keywords_lower = [kw.lower() for kw in (keywords or DEFAULT_KEYWORDS)]
+    keywords_lower = {kw.lower() for kw in (keywords or DEFAULT_KEYWORDS)}
     domain_keywords_lower = {
         domain: [kw.lower() for kw in kws]
         for domain, kws in domain_keywords.items()
@@ -349,8 +354,10 @@ def generate_pmc15_pipeline_outputs(
     with output_file_path.open("w+") as f, (
         domain_caption_output.open("w") if domain_caption_output else contextlib.nullcontext()
     ) as cap_f:
-        for idx, nxml_file in enumerate(decompressed_folder.rglob("*.nxml")):
+        processed_files = 0
+        for nxml_file in decompressed_folder.rglob("*.nxml"):
             parsed = parse_single_pubmed_file(nxml_file)
+            processed_files += 1
 
             for article in parsed:
                 for figure in article["figures"]:
@@ -366,7 +373,7 @@ def generate_pmc15_pipeline_outputs(
 
                 f.write(json.dumps(article) + "\n")
 
-    print(f"Processed {idx+1} files")
+    print(f"Processed {processed_files} files")
 
 
 def count_articles_with_keywords(

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -216,6 +216,7 @@ def download_pubmed_files_from_list(
         repo_root / "_results" / "data" / "pubmed_open_access_files_compressed"
     ),
     subset_size: Optional[int] = None,
+    start_index: int = 0,
     file_extension=".tar.gz",
 ):
     """Download files from PubMed Open Access file list
@@ -232,6 +233,7 @@ def download_pubmed_files_from_list(
 
     output_folder_path.mkdir(parents=True, exist_ok=True)
     skipped_files = []
+    processed_pmcids: list[str] = []
 
     def _get_file_size(url: str) -> int | None:
         response = requests.head(url)
@@ -242,7 +244,9 @@ def download_pubmed_files_from_list(
     with open(file_list_path, "r") as file:
         next(file)  # skip header line
         for line_idx, line in enumerate(file):
-            if subset_size and line_idx >= subset_size:
+            if line_idx < start_index:
+                continue
+            if subset_size and len(processed_pmcids) >= subset_size:
                 break
 
             path, title, pmcid, pmid, code = line.strip().split("\t")
@@ -261,6 +265,7 @@ def download_pubmed_files_from_list(
                 tqdm.write(
                     f"File: {file_name} already exists. Not downloading again."
                 )
+                processed_pmcids.append(pmcid)
                 continue
 
             article_url = PUBMED_OPEN_ACCESS_BASE_URL + path
@@ -285,8 +290,12 @@ def download_pubmed_files_from_list(
                     f"File: {file_name} Skipped! Error occurred: {e}"
                 )
                 skipped_files.append(pubmed_file)
+                continue
+
+            processed_pmcids.append(pmcid)
 
     print(f"Skipped {len(skipped_files)} files.")
+    return processed_pmcids
 
 
 def decompress_pubmed_files(
@@ -297,6 +306,7 @@ def decompress_pubmed_files(
         repo_root / "_results" / "data" / "pubmed_open_access_files"
     ),
     file_extension="*.tar.gz",
+    pmcids: Optional[list[str]] = None,
 ):
     """Decompress article files from PubMed Open Access folder
 
@@ -313,27 +323,37 @@ def decompress_pubmed_files(
     # Ensure output directory exists
     output_folder_path.mkdir(parents=True, exist_ok=True)
 
-    file_paths = list(input_folder_path.glob(file_extension))
+    if pmcids is not None:
+        file_paths = [
+            input_folder_path / f"{pmcid}.tar.gz" for pmcid in pmcids
+            if (input_folder_path / f"{pmcid}.tar.gz").exists()
+        ]
+    else:
+        file_paths = list(input_folder_path.glob(file_extension))
 
     print(
         f"Found {len(file_paths)} files that match {file_extension} in {input_folder_path}"
     )
 
+    extracted: list[str] = []
     for file_path in tqdm(file_paths):
         dest_dir = output_folder_path / file_path.name.replace(".tar.gz", "")
 
         if dest_dir.exists():
             tqdm.write(
                 f"Archive {file_path.name} already extracted. Skipping.")
+            extracted.append(dest_dir.name)
             continue
 
         try:
             with tarfile.open(file_path, "r:gz") as tar_file:
                 tar_file.extractall(output_folder_path)
+            extracted.append(dest_dir.name)
         except (tarfile.TarError, OSError) as err:
             tqdm.write(f"Failed to extract {file_path.name}: {err}")
 
     print(f"Finished extracting {len(file_paths)} files")
+    return extracted
 
 
 def generate_pmc15_pipeline_outputs(
@@ -349,6 +369,8 @@ def generate_pmc15_pipeline_outputs(
     domain_caption_output: Path | None = (
         repo_root / "_results" / "data" / "domain_caption_pairs.jsonl"
     ),
+    pmcids: Optional[list[str]] = None,
+    append: bool = True,
 ):
 
     # input - path to .nxml file for each article in the article package
@@ -472,11 +494,20 @@ def generate_pmc15_pipeline_outputs(
 
             return [article]
 
-    with output_file_path.open("w+") as f, (
-        domain_caption_output.open("w") if domain_caption_output else contextlib.nullcontext()
+    nxml_files: list[Path]
+    if pmcids:
+        nxml_files = []
+        for pmc in pmcids:
+            nxml_files.extend((decompressed_folder / pmc).rglob("*.nxml"))
+    else:
+        nxml_files = list(decompressed_folder.rglob("*.nxml"))
+
+    mode = "a" if append else "w"
+    with output_file_path.open(mode) as f, (
+        domain_caption_output.open(mode) if domain_caption_output else contextlib.nullcontext()
     ) as cap_f:
         processed_files = 0
-        for nxml_file in decompressed_folder.rglob("*.nxml"):
+        for nxml_file in nxml_files:
             parsed = parse_single_pubmed_file(nxml_file)
             processed_files += 1
 
@@ -588,3 +619,40 @@ def export_keyword_caption_pairs(
                 caption = figure.get("fig_caption", "")
                 if any(kw in caption.lower() for kw in keywords_lower):
                     dest.write(json.dumps({"text": caption}) + "\n")
+
+
+def process_in_batches(
+    batch_size: int = 5000,
+    start_index: int = 0,
+    file_list_path: Path = repo_root
+    / "_results"
+    / "data"
+    / "pubmed_open_access_file_list.txt",
+    **kwargs,
+) -> None:
+    """Run the full pipeline in batches to avoid memory pressure.
+
+    Each iteration downloads ``batch_size`` archives, decompresses them,
+    generates caption outputs in append mode, and then advances to the next
+    batch. Existing downloads, extractions, and captions are skipped so the
+    function can resume from a previous run by increasing ``start_index``.
+    Additional keyword or glossary arguments are forwarded to
+    :func:`generate_pmc15_pipeline_outputs`.
+    """
+
+    offset = start_index
+    while True:
+        pmcids = download_pubmed_files_from_list(
+            file_list_path=file_list_path,
+            subset_size=batch_size,
+            start_index=offset,
+        )
+        if not pmcids:
+            break
+
+        extracted = decompress_pubmed_files(pmcids=pmcids)
+        generate_pmc15_pipeline_outputs(pmcids=extracted, append=True, **kwargs)
+
+        offset += batch_size
+        # free memory between batches
+        gc.collect()

--- a/run_keyword_filtered_pipeline.ipynb
+++ b/run_keyword_filtered_pipeline.ipynb
@@ -1,0 +1,68 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PMC15 Pipeline Keyword Demo\n",
+    "This notebook downloads a small subset of PubMed Central Open Access articles and extracts figures whose captions mention pathology-related keywords."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pmc15_pipeline.data import (\n",
+    "    download_pubmed_file_list,\n",
+    "    download_pubmed_files_from_list,\n",
+    "    decompress_pubmed_files,\n",
+    "    generate_pmc15_pipeline_outputs,\n",
+    "    count_articles_with_keywords,\n",
+    "    export_domain_caption_pairs,\n",
+    ")\n",
+    "\n",
+    "# Download the master list of available article packages\n",
+    "download_pubmed_file_list()\n",
+    "\n",
+    "# Download a small subset of article packages (adjust subset_size as needed)\n",
+    "download_pubmed_files_from_list(subset_size=5)\n",
+    "\n",
+    "# Extract the downloaded tar.gz archives\n",
+    "decompress_pubmed_files()\n",
+    "\n",
+    "# Parse figures and captions, keeping only pathology-related captions\n",
+    "generate_pmc15_pipeline_outputs()\n",
+    "\n",
+    "# Count how many articles mention the default keywords\n",
+    "count_articles_with_keywords()\n",
+    "\n",
+    "# Create a domain-caption pairs dataset for downstream use\n",
+    "export_domain_caption_pairs()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `count_articles_with_keywords` helper for tallying figure captions mentioning specified terms
- document keyword counting in README

## Testing
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `flake8` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c4fdb950c8327b115a55dd2a22e36