### PR TITLE
Fix caption filter to honor keyword searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pip install -r requirements.txt
 ## Downloading and Decompressing Articles
 
 ```python
+from pathlib import Path
 from pmc15_pipeline.data import (
     download_pubmed_file_list,
     download_pubmed_files_from_list,
@@ -41,6 +42,8 @@ from pmc15_pipeline.data import (
 
 download_pubmed_file_list()
 download_pubmed_files_from_list(subset_size=100)  # streamed in chunks
+# Or download only specific PMCIDs listed in a text file
+# download_pubmed_files_from_list(pmcids_path=Path("pmc_ids.txt"))
 decompress_pubmed_files()  # skips archives already extracted and continues past errors
 generate_pmc15_pipeline_outputs()  # streams captions to keep memory usage low
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,118 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## Downloading and Decompressing Articles
+
+```python
+from pmc15_pipeline.data import (
+    download_pubmed_file_list,
+    download_pubmed_files_from_list,
+    decompress_pubmed_files,
+)
+
+download_pubmed_file_list()
+download_pubmed_files_from_list(subset_size=100)  # streamed in chunks
+decompress_pubmed_files()  # skips archives already extracted and continues past errors
+generate_pmc15_pipeline_outputs()  # streams captions to keep memory usage low
+```
+
+## Filtering Captions by Keyword
+
+`generate_pmc15_pipeline_outputs` can restrict the dataset to figures whose
+captions mention specific terms. By default it keeps only captions containing
+keywords from these imaging domains:
+
+- **pathology:** "pathology", "whole slide image", "H&E"
+- **x-ray:** "x-ray"
+- **endoscopy:** "endoscopy", "gastrology"
+- **ultra:** "ultrasound"
+- **mri:** "MRI"
+
+Each figure written to `pubmed_parsed_data.json` includes a `domains` array, and
+the enclosing article lists all domains found across its figures. The function
+also writes `_results/data/domain_caption_pairs.jsonl`, containing one line per
+figure-domain combination with the structure `{ "domain": "pathology", "text": "caption" }`.
+Figures lacking any of the keywords are skipped entirely, so a small sample of
+articles may yield an empty output file if none of their captions mention the
+default terms. Captions containing common animal terms (for example “mouse” or
+“rat”) are omitted to focus on human-related content. Set
+`exclude_keywords=None` to include them.
+You can also fetch domain keyword mappings from remote JSON glossaries by
+providing a `glossary_urls` dictionary. Each key is a domain name and each value
+is a URL returning a JSON array of keywords for that domain. Passing a single
+URL is still supported for backward compatibility.
+
+```python
+from pmc15_pipeline.data import generate_pmc15_pipeline_outputs
+
+generate_pmc15_pipeline_outputs()  # Use defaults shown above
+
+# Or provide your own list of keywords
+# generate_pmc15_pipeline_outputs(keywords=["custom term"])
+
+# Include captions mentioning animals
+# generate_pmc15_pipeline_outputs(exclude_keywords=None)
+
+# Pull domain keywords from remote glossaries
+# generate_pmc15_pipeline_outputs(
+#     glossary_urls={
+#         "pathology": "https://example.com/pathology_keywords.json",
+#         "mri": "https://example.com/mri_keywords.json",
+#     }
+# )
+```
+
+## Counting Articles by Domain
+
+After generating `pubmed_parsed_data.json`, you can see how many articles
+mention each domain in their figure captions:
+
+```python
+from pmc15_pipeline.data import count_articles_with_keywords
+
+count_articles_with_keywords()
+
+# Use the same remote glossaries as above
+# count_articles_with_keywords(
+#     glossary_urls={
+#         "pathology": "https://example.com/pathology_keywords.json",
+#         "mri": "https://example.com/mri_keywords.json",
+#     }
+# )
+```
+
+Provide your own list of terms with the `keywords` argument if you want to
+search for different phrases instead of the preset domains.
+
+## Exporting Domain-Caption Pairs
+
+To create a lightweight dataset for domain classification, write one line per
+figure with its domain and caption text:
+
+`generate_pmc15_pipeline_outputs` writes this file automatically; if you need
+to recreate it from an existing dataset, call:
+
+```python
+from pmc15_pipeline.data import export_domain_caption_pairs
+
+export_domain_caption_pairs()
+```
+
+## Exporting Captions with Default Keywords
+
+If you already have `pubmed_parsed_data.json` but only want the captions that
+mention the default imaging-domain keywords, create a lightweight JSONL file:
+
+```python
+from pmc15_pipeline.data import export_keyword_caption_pairs
+
+export_keyword_caption_pairs()
+```
+
+Each line in `_results/data/keyword_caption_pairs.jsonl` has the form
+`{ "text": "caption" }`. Pass your own list of `keywords` to filter for
+different terms.
+
 ## Reference
 ```bibtex
 @article{zhang2024biomedclip,

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ download_pubmed_file_list()
 download_pubmed_files_from_list(subset_size=100)  # streamed in chunks
 # Or download only specific PMCIDs listed in a text file
 # download_pubmed_files_from_list(pmcids_path=Path("pmc_ids.txt"))
+# The PMCID file must exist and contain one ID per line; IDs are
+# matched case-insensitively.
 decompress_pubmed_files()  # skips archives already extracted and continues past errors
 generate_pmc15_pipeline_outputs()  # streams captions to keep memory usage low
 ```

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ generate_pmc15_pipeline_outputs()  # Use defaults shown above
 #         "mri": "https://example.com/mri_keywords.json",
 #     }
 # )
+
+# Run in 5k-file batches
+# batch_size = 5000
+# for batch in range(num_batches):
+#     generate_pmc15_pipeline_outputs(
+#         start_index=batch * batch_size,
+#         max_files=batch_size,
+#         append=batch > 0,
+#     )
 ```
 
 ## Counting Articles by Domain

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -2,6 +2,8 @@ import json
 import tarfile
 from pathlib import Path
 from typing import Optional
+import contextlib
+import gc
 
 import pubmed_parser
 import requests
@@ -13,6 +15,173 @@ from .types import PubMedFile
 from .utils import fs_utils
 
 repo_root = fs_utils.get_repo_root_path()
+
+# Default set of domain keywords; these act as a fallback if a glossary
+# cannot be fetched from a remote source.
+DEFAULT_DOMAIN_KEYWORDS = {
+    "pathology": ["pathology", "whole slide image", "H&E"],
+    "x-ray": ["x-ray"],
+    "endoscopy": ["endoscopy", "gastrology"],
+    "ultra": ["ultrasound"],
+    "mri": ["MRI"],
+}
+
+# Only captions containing these keywords are retained by default. This list
+# combines all domain keywords so the default dataset includes figures from any
+# supported imaging modality.
+DEFAULT_KEYWORDS = [
+    kw for kws in DEFAULT_DOMAIN_KEYWORDS.values() for kw in kws
+]
+
+# Common animal-related terms that should be excluded to focus on human data
+ANIMAL_KEYWORDS = [
+    "mouse",
+    "mice",
+    "murine",
+    "rat",
+    "rats",
+    "rabbit",
+    "rabbits",
+    "canine",
+    "dog",
+    "dogs",
+    "cat",
+    "cats",
+    "feline",
+    "porcine",
+    "pig",
+    "pigs",
+    "swine",
+    "bovine",
+    "cow",
+    "cattle",
+    "sheep",
+    "goat",
+    "hamster",
+    "monkey",
+    "monkeys",
+    "primate",
+    "primates",
+    "zebrafish",
+    "drosophila",
+    "fruit fly",
+    "guinea pig",
+    "ferret",
+]
+
+
+def load_domain_keywords(urls: dict[str, str] | str | None = None) -> dict[str, list[str]]:
+    """Load domain keywords from remote ``urls`` or fall back to defaults.
+
+    ``urls`` may be a single URL pointing to a JSON object mapping domain names
+    to lists of keywords, or a dictionary mapping individual domain names to
+    URLs returning a JSON array for that domain. Failed downloads leave the
+    default keywords in place.
+    """
+
+    keywords = DEFAULT_DOMAIN_KEYWORDS.copy()
+
+    if isinstance(urls, str) and urls:
+        # Backwards compatibility: single URL hosting all domains
+        try:
+            response = requests.get(urls, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            for domain in keywords:
+                if isinstance(data.get(domain), list):
+                    keywords[domain] = data[domain]
+        except requests.RequestException as err:  # pragma: no cover - network
+            print(f"Failed to fetch domain glossary from {urls}: {err}")
+    elif isinstance(urls, dict):
+        for domain, url in urls.items():
+            try:
+                response = requests.get(url, timeout=10)
+                response.raise_for_status()
+                data = response.json()
+                if isinstance(data, list):
+                    keywords[domain] = data
+                elif isinstance(data, dict) and isinstance(data.get(domain), list):
+                    keywords[domain] = data[domain]
+            except requests.RequestException as err:  # pragma: no cover - network
+                print(
+                    f"Failed to fetch domain glossary for '{domain}' from {url}: {err}"
+                )
+
+    return keywords
+
+
+DOMAIN_KEYWORDS = load_domain_keywords()
+DOMAIN_KEYWORDS_LOWER = {
+    domain: [kw.lower() for kw in keywords]
+    for domain, keywords in DOMAIN_KEYWORDS.items()
+}
+
+
+def _basic_caption_parse(nxml_path: Path) -> list[dict]:
+    """Memory-friendly caption parser using ``iterparse``.
+
+    ``pubmed_parser`` loads the entire XML tree into memory which can exceed
+    the container limits for articles embedding large images.  This streaming
+    parser walks the file incrementally and clears elements as soon as they
+    are processed, keeping the memory footprint small.  Only minimal figure
+    metadata is extracted.  Any errors result in an empty list.
+    """
+
+    figures: list[dict] = []
+    pmid = ""
+    pmc = ""
+    current: dict | None = None
+
+    try:
+        # ``huge_tree`` allows lxml to handle base64 encoded images without
+        # exhausting memory; ``iterparse`` ensures elements are discarded as we
+        # progress through the document.
+        context = etree.iterparse(
+            str(nxml_path), events=("start", "end"), recover=True, huge_tree=True
+        )
+    except Exception as err:  # pragma: no cover - parse errors are rare
+        print(f"Fallback parser failed for {nxml_path}: {err}")
+        return []
+
+    for event, elem in context:
+        if event == "start" and elem.tag == "fig":
+            current = {
+                "fig_caption": "",
+                "fig_id": elem.get("id", ""),
+                "fig_label": "",
+                "graphic_ref": "",
+                "pmid": "",
+                "pmc": "",
+                "fig_refs": [],
+            }
+        elif event == "end":
+            if elem.tag == "article-id":
+                id_type = elem.get("pub-id-type")
+                if id_type == "pmid":
+                    pmid = elem.text or ""
+                elif id_type == "pmcid":
+                    pmc = elem.text or ""
+            elif current is not None:
+                if elem.tag == "label":
+                    current["fig_label"] = elem.text or ""
+                elif elem.tag == "caption":
+                    current["fig_caption"] = "".join(elem.itertext()).strip()
+                elif elem.tag == "graphic":
+                    current["graphic_ref"] = elem.get(
+                        "{http://www.w3.org/1999/xlink}href", ""
+                    )
+                elif elem.tag == "fig":
+                    current["pmid"] = pmid
+                    current["pmc"] = pmc
+                    figures.append(current)
+                    current = None
+            # Release memory for processed elements
+            if elem.getparent() is not None:
+                while elem.getprevious() is not None:
+                    del elem.getparent()[0]
+                elem.clear()
+
+    return figures
 
 
 def download_pubmed_file_list(
@@ -61,20 +230,22 @@ def download_pubmed_files_from_list(
         python3 -m data.download_pubmed_files
     """
 
-    # Get dicts from files list
-    pubmed_files: list[PubMedFile] = []
+    output_folder_path.mkdir(parents=True, exist_ok=True)
+    skipped_files = []
+
+    def _get_file_size(url: str) -> int | None:
+        response = requests.head(url)
+        if "Content-Length" in response.headers:
+            return int(response.headers["Content-Length"])
+        return None
 
     with open(file_list_path, "r") as file:
-        lines = file.readlines()
-
-        # Skip header
-        lines = lines[1:]
-
-        for line_idx, line in enumerate(lines):
-            if subset_size and line_idx + 1 > subset_size:
+        next(file)  # skip header line
+        for line_idx, line in enumerate(file):
+            if subset_size and line_idx >= subset_size:
                 break
 
-            [path, title, pmcid, pmid, code] = line.strip().split("\t")
+            path, title, pmcid, pmid, code = line.strip().split("\t")
             pubmed_file: PubMedFile = {
                 "path": path,
                 "title": title,
@@ -82,50 +253,38 @@ def download_pubmed_files_from_list(
                 "pmid": pmid,
                 "code": code,
             }
-            pubmed_files.append(pubmed_file)
 
-    # Create output folder
-    output_folder_path.mkdir(parents=True, exist_ok=True)
-    skipped_files = []
+            file_name = pmcid + file_extension
+            file_path = output_folder_path / file_name
 
-    def _get_file_size(url):
-        response = requests.head(url)
-        if "Content-Length" in response.headers:
-            return int(response.headers["Content-Length"])
-        else:
-            return None
+            if file_path.exists():
+                tqdm.write(
+                    f"File: {file_name} already exists. Not downloading again."
+                )
+                continue
 
-    for pubmed_file in tqdm(pubmed_files):
-        file_name = pubmed_file["pmcid"] + file_extension
-        file_path = output_folder_path / file_name
+            article_url = PUBMED_OPEN_ACCESS_BASE_URL + path
+            file_size = _get_file_size(article_url)
+            if file_size is None:
+                tqdm.write(
+                    f"File: {file_name} Skipped! Could not get file size!"
+                )
+                skipped_files.append(pubmed_file)
+                continue
 
-        # Check if the file already exists
-        if file_path.exists():
-            tqdm.write(f"File: {file_name} already exists. Not downloading again.")
-            continue
-
-        article_url = PUBMED_OPEN_ACCESS_BASE_URL + pubmed_file["path"]
-        file_size = _get_file_size(article_url)
-
-        if file_size is not None:
             tqdm.write(f"File: {file_name} size: {file_size} bytes")
             try:
-                response = requests.get(article_url)
-                response.raise_for_status()  # Raise an HTTPError for bad responses
-
-                with open(file_path, "wb") as file:
-                    file.write(response.content)
-
-            except requests.exceptions.RequestException as e:
-                tqdm.write(f"File: {file_name} Skipped! Error occurred: {e}")
+                with requests.get(article_url, stream=True, timeout=30) as r:
+                    r.raise_for_status()
+                    with open(file_path, "wb") as f_out:
+                        for chunk in r.iter_content(chunk_size=8192):
+                            if chunk:
+                                f_out.write(chunk)
+            except requests.RequestException as e:
+                tqdm.write(
+                    f"File: {file_name} Skipped! Error occurred: {e}"
+                )
                 skipped_files.append(pubmed_file)
-
-            with open(file_path, "wb") as file:
-                file.write(response.content)
-
-        else:
-            tqdm.write(f"File: {file_name} Skipped! Could not get file size!")
-            skipped_files.append(pubmed_file)
 
     print(f"Skipped {len(skipped_files)} files.")
 
@@ -151,7 +310,9 @@ def decompress_pubmed_files(
         python3 -m data.decompress_pubmed_files
     """
 
-    # Get dicts from files list
+    # Ensure output directory exists
+    output_folder_path.mkdir(parents=True, exist_ok=True)
+
     file_paths = list(input_folder_path.glob(file_extension))
 
     print(
@@ -159,10 +320,18 @@ def decompress_pubmed_files(
     )
 
     for file_path in tqdm(file_paths):
-        with tarfile.open(file_path, "r:gz") as tar_file:
-            # TODO: Use article folder path instead of output folder path?
-            # Causes duplicate folder names since tar file contains folder
-            tar_file.extractall(output_folder_path)
+        dest_dir = output_folder_path / file_path.name.replace(".tar.gz", "")
+
+        if dest_dir.exists():
+            tqdm.write(
+                f"Archive {file_path.name} already extracted. Skipping.")
+            continue
+
+        try:
+            with tarfile.open(file_path, "r:gz") as tar_file:
+                tar_file.extractall(output_folder_path)
+        except (tarfile.TarError, OSError) as err:
+            tqdm.write(f"Failed to extract {file_path.name}: {err}")
 
     print(f"Finished extracting {len(file_paths)} files")
 
@@ -174,10 +343,29 @@ def generate_pmc15_pipeline_outputs(
     output_file_path: Path = (
         repo_root / "_results" / "data" / "pubmed_parsed_data.json"
     ),
+    keywords: list[str] | None = None,
+    glossary_urls: dict[str, str] | str | None = None,
+    exclude_keywords: list[str] | None = ANIMAL_KEYWORDS,
+    domain_caption_output: Path | None = (
+        repo_root / "_results" / "data" / "domain_caption_pairs.jsonl"
+    ),
 ):
 
     # input - path to .nxml file for each article in the article package
     # output - json object with pmid, pmc id, location (path to article package in storage blobs), figures - list of figure objects which include inline references (mentions of figure throughout the article), caption for the figure, id, label, graphic_ref (filepath to figure jpg in storage blobs), pair_id (a unique id to identify each figure in the article, using pmid + figure_id)
+    # Ensure destination directories exist before any processing occurs
+    output_file_path.parent.mkdir(parents=True, exist_ok=True)
+    if domain_caption_output:
+        Path(domain_caption_output).parent.mkdir(parents=True, exist_ok=True)
+
+    domain_keywords = load_domain_keywords(glossary_urls)
+    keywords_lower = {kw.lower() for kw in (keywords or DEFAULT_KEYWORDS)}
+    exclude_lower = [kw.lower() for kw in (exclude_keywords or [])]
+    domain_keywords_lower = {
+        domain: [kw.lower() for kw in kws]
+        for domain, kws in domain_keywords.items()
+    }
+
     def parse_single_pubmed_file(nxml_path: Path):
         print(nxml_path)
 
@@ -185,81 +373,218 @@ def generate_pmc15_pipeline_outputs(
             print("error")
             return []
 
+        print("starting...")
+        output: list[dict] = []
         try:
-            print("starting...")
-            output = pubmed_parser.parse_pubmed_caption(str(nxml_path.absolute()))
-            print("parsed", nxml_path)
-        except AttributeError as ae:
-            print("Attribute Error: " + str(ae) + " path: " + str(nxml_path))
-            return []
-        except etree.XMLSyntaxError as xmle:
-            print("XML Syntax Error: " + str(xmle) + " path: " + str(nxml_path))
-            return []
-        except Exception as e:
-            print("Exception: " + str(e) + " path: " + str(nxml_path))
-            return []
+            if nxml_path.stat().st_size > 5_000_000:
+                # Large XML files often embed images and may exhaust memory
+                output = _basic_caption_parse(nxml_path)
+            else:
+                output = pubmed_parser.parse_pubmed_caption(
+                    str(nxml_path.absolute())
+                )
+            if not output:
+                output = _basic_caption_parse(nxml_path)
+        except MemoryError:
+            # OOM while using pubmed_parser; retry with streaming parser
+            print("MemoryError: falling back to lightweight parser")
+            output = _basic_caption_parse(nxml_path)
+        except UnboundLocalError as err:
+            # Some articles trigger a bug in pubmed_parser referencing an
+            # undefined 'caption' variable.  Fall back to the lightweight parser
+            # without treating it as a fatal error.
+            print(f"Parser bug in pubmed_parser for {nxml_path}: {err}")
+            output = _basic_caption_parse(nxml_path)
+        except Exception as err:  # pragma: no cover - unexpected parse errors
+            print(f"Error parsing {nxml_path}: {err}")
+            output = _basic_caption_parse(nxml_path)
 
         if not output:
             print("no output")
             return []
 
-        else:
-            figures = []
-            pmid = output[0]["pmid"]  # same for all figures in the article
-            pmc = output[0]["pmc"]  # same for all figures in the article
-            location = Path(nxml_path).parent
+        print("parsed", nxml_path)
 
-            # for all figures in the article, create a figure object with inline references (text, section, reference_id), and caption, id, label, graphic_ref, pair_id
-            for figure_dict in output:
-                inline_references = figure_dict.get(
-                    "fig_refs", {}
-                )  # from pubmed parser
-                ir_objects = []
-                for inline_reference in inline_references:
-                    inline_reference_object = {
-                        "text": str(inline_reference.get("text", "")),
-                        "section": str(inline_reference.get("section", "")),
-                        "reference_id": str(inline_reference.get("reference_id", "")),
-                    }
+        figures = []
+        pmid = output[0]["pmid"]  # same for all figures in the article
+        pmc = output[0]["pmc"]  # same for all figures in the article
+        location = Path(nxml_path).parent
 
-                    ir_objects.append(inline_reference_object)
-
-                if len(ir_objects) > 0:
-                    raise NotImplementedError("Inline references not implemented")
-
-                figure_object = {
-                    "fig_caption": str(figure_dict.get("fig_caption", "")),
-                    "fig_id": str(figure_dict.get("fig_id", "")),
-                    "fig_label": str(figure_dict.get("fig_label", "")),
-                    "graphic_ref": (
-                        str(location / (figure_dict["graphic_ref"] + ".jpg"))
-                        if "graphic_ref" in figure_dict
-                        else ""
-                    ),  # set this to the path of the jpg image in storage blobs
-                    "pair_id": str(pmid) + "_" + str(figure_dict.get("fig_id", "")),
-                    "inline_references": ir_objects,  # add inline references
+        # for all figures in the article, create a figure object with inline references (text, section, reference_id), and caption, id, label, graphic_ref, pair_id
+        for figure_dict in output:
+            inline_references = figure_dict.get(
+                "fig_refs", {}
+            )  # from pubmed parser
+            ir_objects = []
+            for inline_reference in inline_references:
+                inline_reference_object = {
+                    "text": str(inline_reference.get("text", "")),
+                    "section": str(inline_reference.get("section", "")),
+                    "reference_id": str(inline_reference.get("reference_id", "")),
                 }
 
-                figures.append(figure_object)
+                ir_objects.append(inline_reference_object)
 
-            article = {
-                "pmid": pmid,
-                "pmc": pmc,
-                "location": str(location),
-                "figures": figures,
+            if len(ir_objects) > 0:
+                raise NotImplementedError("Inline references not implemented")
+
+            caption = str(figure_dict.get("fig_caption", ""))
+            caption_lower = caption.lower()
+            if exclude_lower and any(kw in caption_lower for kw in exclude_lower):
+                continue
+            if not any(kw in caption_lower for kw in keywords_lower):
+                continue
+
+            domains = [
+                domain
+                for domain, kws in domain_keywords_lower.items()
+                if any(kw in caption_lower for kw in kws)
+            ]
+            if not domains:
+                continue
+
+            figure_object = {
+                "fig_caption": caption,
+                "fig_id": str(figure_dict.get("fig_id", "")),
+                "fig_label": str(figure_dict.get("fig_label", "")),
+                "graphic_ref": (
+                    str(location / (figure_dict["graphic_ref"] + ".jpg"))
+                    if "graphic_ref" in figure_dict
+                    else ""
+                ),  # set this to the path of the jpg image in storage blobs
+                "pair_id": str(pmid) + "_" + str(figure_dict.get("fig_id", "")),
+                "inline_references": ir_objects,  # add inline references
+                "domains": domains,
             }
 
-            return [article]
+            figures.append(figure_object)
 
-    with output_file_path.open("w+") as f:
-        for idx, nxml_file in enumerate(decompressed_folder.rglob("*.nxml")):
+        if not figures:
+            return []
+
+        article = {
+            "pmid": pmid,
+            "pmc": pmc,
+            "location": str(location),
+            "figures": figures,
+            "domains": sorted({d for fig in figures for d in fig["domains"]}),
+        }
+
+        return [article]
+
+    with output_file_path.open("w+") as f, (
+        domain_caption_output.open("w") if domain_caption_output else contextlib.nullcontext()
+    ) as cap_f:
+        processed_files = 0
+        for nxml_file in decompressed_folder.rglob("*.nxml"):
             parsed = parse_single_pubmed_file(nxml_file)
+            processed_files += 1
 
             for article in parsed:
                 for figure in article["figures"]:
                     # remove inline references since we're not using them
                     figure.pop("inline_references")
+                    if cap_f:
+                        caption = figure.get("fig_caption", "")
+                        for domain in figure.get("domains", []):
+                            cap_f.write(
+                                json.dumps({"domain": domain, "text": caption})
+                                + "\n"
+                            )
 
                 f.write(json.dumps(article) + "\n")
+            gc.collect()
+    print(f"Processed {processed_files} files")
 
-    print(f"Processed {idx+1} files")
+
+def count_articles_with_keywords(
+    dataset_path: Path = repo_root / "_results" / "data" / "pubmed_parsed_data.json",
+    keywords: list[str] | None = None,
+    domain_keywords: dict[str, list[str]] | None = None,
+    glossary_urls: dict[str, str] | str | None = None,
+) -> dict[str, int]:
+    """Count articles whose figure captions mention given keywords or domains."""
+
+    if keywords is not None:
+        keyword_counts = {kw.lower(): 0 for kw in keywords}
+    else:
+        domain_keywords = domain_keywords or load_domain_keywords(glossary_urls)
+        domain_keywords_lower = {
+            domain: [kw.lower() for kw in kws]
+            for domain, kws in domain_keywords.items()
+        }
+        keyword_counts = {domain: 0 for domain in domain_keywords}
+
+    with dataset_path.open("r") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            article = json.loads(line)
+            captions = " ".join(
+                fig.get("fig_caption", "") for fig in article.get("figures", [])
+            ).lower()
+            if keywords is not None:
+                for kw in keyword_counts:
+                    if kw in captions:
+                        keyword_counts[kw] += 1
+            else:
+                for domain, kws in domain_keywords_lower.items():
+                    if any(kw in captions for kw in kws):
+                        keyword_counts[domain] += 1
+
+    print("Article counts:", keyword_counts)
+    return keyword_counts
+
+
+def export_domain_caption_pairs(
+    dataset_path: Path = repo_root / "_results" / "data" / "pubmed_parsed_data.json",
+    output_path: Path = repo_root
+    / "_results"
+    / "data"
+    / "domain_caption_pairs.jsonl",
+) -> None:
+    """Write ``{"domain": d, "text": caption}`` pairs for each figure.
+
+    One line is written for every domain assigned to a figure in
+    ``dataset_path``. Figures with multiple domains will produce multiple
+    entries with the same caption.
+    """
+
+    with dataset_path.open("r") as src, output_path.open("w") as dest:
+        for line in src:
+            if not line.strip():
+                continue
+            article = json.loads(line)
+            for figure in article.get("figures", []):
+                caption = figure.get("fig_caption", "")
+                for domain in figure.get("domains", []):
+                    dest.write(
+                        json.dumps({"domain": domain, "text": caption}) + "\n"
+                    )
+
+
+def export_keyword_caption_pairs(
+    dataset_path: Path = repo_root / "_results" / "data" / "pubmed_parsed_data.json",
+    output_path: Path = repo_root
+    / "_results"
+    / "data"
+    / "keyword_caption_pairs.jsonl",
+    keywords: list[str] | None = None,
+) -> None:
+    """Write captions containing ``keywords`` to ``output_path``.
+
+    Each line of the resulting JSONL file has the structure
+    ``{"text": "caption"}``. ``keywords`` defaults to ``DEFAULT_KEYWORDS``.
+    """
+
+    keywords_lower = [kw.lower() for kw in (keywords or DEFAULT_KEYWORDS)]
+
+    with dataset_path.open("r") as src, output_path.open("w") as dest:
+        for line in src:
+            if not line.strip():
+                continue
+            article = json.loads(line)
+            for figure in article.get("figures", []):
+                caption = figure.get("fig_caption", "")
+                if any(kw in caption.lower() for kw in keywords_lower):
+                    dest.write(json.dumps({"text": caption}) + "\n")

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -349,10 +349,22 @@ def generate_pmc15_pipeline_outputs(
     domain_caption_output: Path | None = (
         repo_root / "_results" / "data" / "domain_caption_pairs.jsonl"
     ),
+    start_index: int = 0,
+    max_files: int | None = None,
+    append: bool = False,
 ):
+    """Parse figure captions and write them to a JSONL dataset.
 
-    # input - path to .nxml file for each article in the article package
-    # output - json object with pmid, pmc id, location (path to article package in storage blobs), figures - list of figure objects which include inline references (mentions of figure throughout the article), caption for the figure, id, label, graphic_ref (filepath to figure jpg in storage blobs), pair_id (a unique id to identify each figure in the article, using pmid + figure_id)
+    Parameters
+    ----------
+    start_index:
+        Skip this many ``.nxml`` files before processing.
+    max_files:
+        Process at most this many files; ``None`` means no limit.
+    append:
+        Append to output files if ``True`` instead of overwriting.
+    """
+
     # Ensure destination directories exist before any processing occurs
     output_file_path.parent.mkdir(parents=True, exist_ok=True)
     if domain_caption_output:
@@ -472,11 +484,18 @@ def generate_pmc15_pipeline_outputs(
 
         return [article]
 
-    with output_file_path.open("w+") as f, (
-        domain_caption_output.open("w") if domain_caption_output else contextlib.nullcontext()
+    file_mode = "a" if append else "w"
+    with output_file_path.open(file_mode) as f, (
+        domain_caption_output.open(file_mode)
+        if domain_caption_output
+        else contextlib.nullcontext()
     ) as cap_f:
         processed_files = 0
-        for nxml_file in decompressed_folder.rglob("*.nxml"):
+        for idx, nxml_file in enumerate(decompressed_folder.rglob("*.nxml")):
+            if idx < start_index:
+                continue
+            if max_files is not None and (idx - start_index) >= max_files:
+                break
             parsed = parse_single_pubmed_file(nxml_file)
             processed_files += 1
 

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -217,6 +217,7 @@ def download_pubmed_files_from_list(
     ),
     subset_size: Optional[int] = None,
     file_extension=".tar.gz",
+    pmcids_path: Path | None = None,
 ):
     """Download files from PubMed Open Access file list
 
@@ -224,6 +225,7 @@ def download_pubmed_files_from_list(
         file_list_path (Path, optional): Path to PubMed Open Access Files list. Defaults to "_results/data/pubmed_open_access_file_list_top_100.txt".
         output_folder_path (Path, optional): Path to save directory. Defaults to repo_root/"_results"/"data"/"pubmed_open_access_files_compressed".
         subset_size (int, optional): Number of files to download. Defaults to None (download all files).
+        pmcids_path (Path, optional): Text file containing one PMCID per line.
 
     Example:
 
@@ -233,6 +235,11 @@ def download_pubmed_files_from_list(
     output_folder_path.mkdir(parents=True, exist_ok=True)
     skipped_files = []
 
+    pmcid_filter: set[str] | None = None
+    if pmcids_path and pmcids_path.exists():
+        with open(pmcids_path, "r") as pmc_file:
+            pmcid_filter = {line.strip() for line in pmc_file if line.strip()}
+
     def _get_file_size(url: str) -> int | None:
         response = requests.head(url)
         if "Content-Length" in response.headers:
@@ -241,11 +248,15 @@ def download_pubmed_files_from_list(
 
     with open(file_list_path, "r") as file:
         next(file)  # skip header line
-        for line_idx, line in enumerate(file):
-            if subset_size and line_idx >= subset_size:
+        downloaded = 0
+        for line in file:
+            path, title, pmcid, pmid, code = line.strip().split("\t")
+
+            if pmcid_filter and pmcid not in pmcid_filter:
+                continue
+            if subset_size and downloaded >= subset_size:
                 break
 
-            path, title, pmcid, pmid, code = line.strip().split("\t")
             pubmed_file: PubMedFile = {
                 "path": path,
                 "title": title,
@@ -261,6 +272,8 @@ def download_pubmed_files_from_list(
                 tqdm.write(
                     f"File: {file_name} already exists. Not downloading again."
                 )
+                if pmcid_filter:
+                    pmcid_filter.discard(pmcid)
                 continue
 
             article_url = PUBMED_OPEN_ACCESS_BASE_URL + path
@@ -285,6 +298,12 @@ def download_pubmed_files_from_list(
                     f"File: {file_name} Skipped! Error occurred: {e}"
                 )
                 skipped_files.append(pubmed_file)
+
+            downloaded += 1
+            if pmcid_filter:
+                pmcid_filter.discard(pmcid)
+                if not pmcid_filter:
+                    break
 
     print(f"Skipped {len(skipped_files)} files.")
 

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -226,6 +226,7 @@ def download_pubmed_files_from_list(
         output_folder_path (Path, optional): Path to save directory. Defaults to repo_root/"_results"/"data"/"pubmed_open_access_files_compressed".
         subset_size (int, optional): Number of files to download. Defaults to None (download all files).
         pmcids_path (Path, optional): Text file containing one PMCID per line.
+            The file must exist; IDs are matched case-insensitively.
 
     Example:
 
@@ -236,9 +237,15 @@ def download_pubmed_files_from_list(
     skipped_files = []
 
     pmcid_filter: set[str] | None = None
-    if pmcids_path and pmcids_path.exists():
+    if pmcids_path:
+        if not pmcids_path.exists():
+            raise FileNotFoundError(f"PMCID list not found: {pmcids_path}")
         with open(pmcids_path, "r") as pmc_file:
-            pmcid_filter = {line.strip() for line in pmc_file if line.strip()}
+            pmcid_filter = {
+                line.strip().upper() for line in pmc_file if line.strip()
+            }
+        if not pmcid_filter:
+            raise ValueError(f"No PMCIDs found in {pmcids_path}")
 
     def _get_file_size(url: str) -> int | None:
         response = requests.head(url)
@@ -251,8 +258,9 @@ def download_pubmed_files_from_list(
         downloaded = 0
         for line in file:
             path, title, pmcid, pmid, code = line.strip().split("\t")
+            pmcid_upper = pmcid.upper()
 
-            if pmcid_filter and pmcid not in pmcid_filter:
+            if pmcid_filter and pmcid_upper not in pmcid_filter:
                 continue
             if subset_size and downloaded >= subset_size:
                 break
@@ -265,7 +273,7 @@ def download_pubmed_files_from_list(
                 "code": code,
             }
 
-            file_name = pmcid + file_extension
+            file_name = pmcid_upper + file_extension
             file_path = output_folder_path / file_name
 
             if file_path.exists():
@@ -273,7 +281,7 @@ def download_pubmed_files_from_list(
                     f"File: {file_name} already exists. Not downloading again."
                 )
                 if pmcid_filter:
-                    pmcid_filter.discard(pmcid)
+                    pmcid_filter.discard(pmcid_upper)
                 continue
 
             article_url = PUBMED_OPEN_ACCESS_BASE_URL + path
@@ -301,10 +309,15 @@ def download_pubmed_files_from_list(
 
             downloaded += 1
             if pmcid_filter:
-                pmcid_filter.discard(pmcid)
+                pmcid_filter.discard(pmcid_upper)
                 if not pmcid_filter:
                     break
 
+    if pmcid_filter:
+        print(
+            f"Warning: {len(pmcid_filter)} PMCIDs were not found in the file list: "
+            f"{', '.join(sorted(pmcid_filter)[:5])}"
+        )
     print(f"Skipped {len(skipped_files)} files.")
 
 

--- a/run_keyword_filtered_pipeline.ipynb
+++ b/run_keyword_filtered_pipeline.ipynb
@@ -1,0 +1,68 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PMC15 Pipeline Keyword Demo\n",
+    "This notebook downloads a small subset of PubMed Central Open Access articles and extracts figures whose captions mention pathology-related keywords."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pmc15_pipeline.data import (\n",
+    "    download_pubmed_file_list,\n",
+    "    download_pubmed_files_from_list,\n",
+    "    decompress_pubmed_files,\n",
+    "    generate_pmc15_pipeline_outputs,\n",
+    "    count_articles_with_keywords,\n",
+    "    export_domain_caption_pairs,\n",
+    ")\n",
+    "\n",
+    "# Download the master list of available article packages\n",
+    "download_pubmed_file_list()\n",
+    "\n",
+    "# Download a small subset of article packages (adjust subset_size as needed)\n",
+    "download_pubmed_files_from_list(subset_size=5)\n",
+    "\n",
+    "# Extract the downloaded tar.gz archives\n",
+    "decompress_pubmed_files()\n",
+    "\n",
+    "# Parse figures and captions, keeping only pathology-related captions\n",
+    "generate_pmc15_pipeline_outputs()\n",
+    "\n",
+    "# Count how many articles mention the default keywords\n",
+    "count_articles_with_keywords()\n",
+    "\n",
+    "# Create a domain-caption pairs dataset for downstream use\n",
+    "export_domain_caption_pairs()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- ensure figure captions are filtered against keyword list before writing articles
- skip articles without matching captions to keep counts accurate

## Testing
- `python -m py_compile pmc15_pipeline/data.py`


------
https://chatgpt.com/codex/tasks/task_b_689c4fdb950c8327b115a55dd2a22e36