### PR TITLE
Add script to export PubMed figure captions to CSV with optional parsing/decompression

### DIFF
--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -159,10 +159,13 @@ def decompress_pubmed_files(
     )
 
     for file_path in tqdm(file_paths):
-        with tarfile.open(file_path, "r:gz") as tar_file:
-            # TODO: Use article folder path instead of output folder path?
-            # Causes duplicate folder names since tar file contains folder
-            tar_file.extractall(output_folder_path)
+        try:
+            with tarfile.open(file_path, "r:gz") as tar_file:
+                # TODO: Use article folder path instead of output folder path?
+                # Causes duplicate folder names since tar file contains folder
+                tar_file.extractall(output_folder_path)
+        except (tarfile.TarError, EOFError) as exc:
+            tqdm.write(f"Failed to extract {file_path}: {exc}")
 
     print(f"Finished extracting {len(file_paths)} files")
 

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -252,8 +252,9 @@ def generate_pmc15_pipeline_outputs(
 
             return [article]
 
+    processed_count = 0
     with output_file_path.open("w+") as f:
-        for idx, nxml_file in enumerate(decompressed_folder.rglob("*.nxml")):
+        for nxml_file in decompressed_folder.rglob("*.nxml"):
             parsed = parse_single_pubmed_file(nxml_file)
 
             for article in parsed:
@@ -262,5 +263,6 @@ def generate_pmc15_pipeline_outputs(
                     figure.pop("inline_references")
 
                 f.write(json.dumps(article) + "\n")
+                processed_count += 1
 
-    print(f"Processed {idx+1} files")
+    print(f"Processed {processed_count} files")

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -246,15 +246,16 @@ def generate_pmc15_pipeline_outputs(
                 if len(ir_objects) > 0:
                     raise NotImplementedError("Inline references not implemented")
 
+                graphic_ref = figure_dict.get("graphic_ref")
+                graphic_ref_path = (
+                    str(location / f"{graphic_ref}.jpg") if graphic_ref else ""
+                )
+
                 figure_object = {
                     "fig_caption": str(figure_dict.get("fig_caption", "")),
                     "fig_id": str(figure_dict.get("fig_id", "")),
                     "fig_label": str(figure_dict.get("fig_label", "")),
-                    "graphic_ref": (
-                        str(location / (figure_dict["graphic_ref"] + ".jpg"))
-                        if "graphic_ref" in figure_dict
-                        else ""
-                    ),  # set this to the path of the jpg image in storage blobs
+                    "graphic_ref": graphic_ref_path,
                     "pair_id": str(pmid) + "_" + str(figure_dict.get("fig_id", "")),
                     "inline_references": ir_objects,  # add inline references
                 }

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -175,6 +175,7 @@ def generate_pmc15_pipeline_outputs(
         repo_root / "_results" / "data" / "pubmed_parsed_data.json"
     ),
 ):
+    output_file_path.parent.mkdir(parents=True, exist_ok=True)
 
     # input - path to .nxml file for each article in the article package
     # output - json object with pmid, pmc id, location (path to article package in storage blobs), figures - list of figure objects which include inline references (mentions of figure throughout the article), caption for the figure, id, label, graphic_ref (filepath to figure jpg in storage blobs), pair_id (a unique id to identify each figure in the article, using pmid + figure_id)

--- a/pmc15_pipeline/data.py
+++ b/pmc15_pipeline/data.py
@@ -138,6 +138,7 @@ def decompress_pubmed_files(
         repo_root / "_results" / "data" / "pubmed_open_access_files"
     ),
     file_extension="*.tar.gz",
+    skip_existing: bool = True,
 ):
     """Decompress article files from PubMed Open Access folder
 
@@ -161,6 +162,20 @@ def decompress_pubmed_files(
     for file_path in tqdm(file_paths):
         try:
             with tarfile.open(file_path, "r:gz") as tar_file:
+                if skip_existing:
+                    top_level_dirs = {
+                        Path(member.name).parts[0]
+                        for member in tar_file.getmembers()
+                        if member.name
+                    }
+                    if top_level_dirs and all(
+                        (output_folder_path / entry).exists()
+                        for entry in top_level_dirs
+                    ):
+                        tqdm.write(
+                            f"Skipping {file_path}: already extracted."
+                        )
+                        continue
                 # TODO: Use article folder path instead of output folder path?
                 # Causes duplicate folder names since tar file contains folder
                 tar_file.extractall(output_folder_path)

--- a/run_keyword_caption_export.py
+++ b/run_keyword_caption_export.py
@@ -95,15 +95,15 @@ def _iter_parsed_articles_from_nxml(decompressed_folder: Path) -> list[dict]:
         location = Path(nxml_path).parent
 
         for figure_dict in output:
+            graphic_ref = figure_dict.get("graphic_ref")
+            graphic_ref_path = (
+                str(location / f"{graphic_ref}.jpg") if graphic_ref else ""
+            )
             figure_object = {
                 "fig_caption": str(figure_dict.get("fig_caption", "")),
                 "fig_id": str(figure_dict.get("fig_id", "")),
                 "fig_label": str(figure_dict.get("fig_label", "")),
-                "graphic_ref": (
-                    str(location / (figure_dict["graphic_ref"] + ".jpg"))
-                    if "graphic_ref" in figure_dict
-                    else ""
-                ),
+                "graphic_ref": graphic_ref_path,
                 "pair_id": str(pmid) + "_" + str(figure_dict.get("fig_id", "")),
             }
             figures.append(figure_object)
@@ -129,16 +129,16 @@ def _maybe_decompress(
     decompressed_folder: Path,
     decompress: bool,
 ) -> None:
+    if decompressed_folder.exists() and any(
+        decompressed_folder.rglob("*.nxml")
+    ):
+        return
+
     if decompress:
         data.decompress_pubmed_files(
             input_folder_path=compressed_folder,
             output_folder_path=decompressed_folder,
         )
-        return
-
-    if decompressed_folder.exists() and any(
-        decompressed_folder.rglob("*.nxml")
-    ):
         return
 
     if not compressed_folder.exists():

--- a/run_keyword_caption_export.py
+++ b/run_keyword_caption_export.py
@@ -11,6 +11,11 @@ import argparse
 import csv
 import json
 from pathlib import Path
+from typing import Iterable
+
+import pubmed_parser
+from lxml import etree
+from tqdm import tqdm
 
 from pmc15_pipeline import data
 
@@ -27,7 +32,7 @@ def _load_parsed_articles(parsed_jsonl: Path) -> list[dict]:
 
 
 def _export_to_csv(
-    articles: list[dict],
+    articles: Iterable[dict],
     output_csv: Path,
     append: bool,
 ) -> None:
@@ -65,6 +70,57 @@ def _export_to_csv(
                         "pair_id": figure.get("pair_id", ""),
                     }
                 )
+
+
+def _iter_parsed_articles_from_nxml(decompressed_folder: Path) -> list[dict]:
+    def parse_single_pubmed_file(nxml_path: Path) -> list[dict]:
+        if nxml_path is None or not nxml_path.exists():
+            return []
+
+        try:
+            output = pubmed_parser.parse_pubmed_caption(str(nxml_path.absolute()))
+        except AttributeError:
+            return []
+        except etree.XMLSyntaxError:
+            return []
+        except Exception:
+            return []
+
+        if not output:
+            return []
+
+        figures = []
+        pmid = output[0].get("pmid", "")
+        pmc = output[0].get("pmc", "")
+        location = Path(nxml_path).parent
+
+        for figure_dict in output:
+            figure_object = {
+                "fig_caption": str(figure_dict.get("fig_caption", "")),
+                "fig_id": str(figure_dict.get("fig_id", "")),
+                "fig_label": str(figure_dict.get("fig_label", "")),
+                "graphic_ref": (
+                    str(location / (figure_dict["graphic_ref"] + ".jpg"))
+                    if "graphic_ref" in figure_dict
+                    else ""
+                ),
+                "pair_id": str(pmid) + "_" + str(figure_dict.get("fig_id", "")),
+            }
+            figures.append(figure_object)
+
+        article = {
+            "pmid": pmid,
+            "pmc": pmc,
+            "location": str(location),
+            "figures": figures,
+        }
+
+        return [article]
+
+    articles: list[dict] = []
+    for nxml_file in tqdm(decompressed_folder.rglob("*.nxml")):
+        articles.extend(parse_single_pubmed_file(nxml_file))
+    return articles
 
 
 def main() -> None:
@@ -116,10 +172,20 @@ def main() -> None:
             "instead."
         ),
     )
+    parser.add_argument(
+        "--no-json",
+        action="store_true",
+        help="Skip writing the intermediate JSONL file and parse directly to CSV.",
+    )
 
     args = parser.parse_args()
 
-    if not args.skip_pubmed_parser:
+    if args.no_json and args.skip_pubmed_parser:
+        raise ValueError(
+            "--no-json cannot be combined with --skip-pubmed-parser."
+        )
+
+    if not args.skip_pubmed_parser and not args.no_json:
         if args.decompress:
             data.decompress_pubmed_files(
                 input_folder_path=args.compressed_folder,
@@ -136,7 +202,21 @@ def main() -> None:
             "--skip-pubmed-parser or provide an existing --parsed-jsonl path."
         )
 
-    articles = _load_parsed_articles(args.parsed_jsonl)
+    if args.no_json:
+        if args.decompress:
+            data.decompress_pubmed_files(
+                input_folder_path=args.compressed_folder,
+                output_folder_path=args.decompressed_folder,
+            )
+        if not args.decompressed_folder.exists():
+            raise FileNotFoundError(
+                "Decompressed folder not found. Provide --decompressed-folder "
+                "or pass --decompress to extract archives."
+            )
+        articles = _iter_parsed_articles_from_nxml(args.decompressed_folder)
+    else:
+        articles = _load_parsed_articles(args.parsed_jsonl)
+
     _export_to_csv(articles, args.output_csv, args.append)
 
 

--- a/run_keyword_caption_export.py
+++ b/run_keyword_caption_export.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+"""Export PubMed figure captions to CSV.
+
+This script optionally decompresses PubMed Open Access archives, parses captions
+with ``pubmed_parser``, and exports figure metadata to a CSV file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+from pmc15_pipeline import data
+
+
+def _load_parsed_articles(parsed_jsonl: Path) -> list[dict]:
+    articles: list[dict] = []
+    with parsed_jsonl.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            articles.append(json.loads(line))
+    return articles
+
+
+def _export_to_csv(
+    articles: list[dict],
+    output_csv: Path,
+    append: bool,
+) -> None:
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    write_header = True
+    if append and output_csv.exists():
+        write_header = False
+
+    fieldnames = [
+        "pmid",
+        "pmc",
+        "fig_id",
+        "fig_label",
+        "fig_caption",
+        "graphic_ref",
+        "pair_id",
+    ]
+
+    mode = "a" if append else "w"
+    with output_csv.open(mode, newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        if write_header:
+            writer.writeheader()
+
+        for article in articles:
+            for figure in article.get("figures", []):
+                writer.writerow(
+                    {
+                        "pmid": article.get("pmid", ""),
+                        "pmc": article.get("pmc", ""),
+                        "fig_id": figure.get("fig_id", ""),
+                        "fig_label": figure.get("fig_label", ""),
+                        "fig_caption": figure.get("fig_caption", ""),
+                        "graphic_ref": figure.get("graphic_ref", ""),
+                        "pair_id": figure.get("pair_id", ""),
+                    }
+                )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export PubMed figure captions to CSV."
+    )
+    parser.add_argument(
+        "--decompressed-folder",
+        type=Path,
+        default=data.repo_root / "_results" / "data" / "pubmed_open_access_files",
+        help="Folder containing decompressed PubMed Open Access files.",
+    )
+    parser.add_argument(
+        "--compressed-folder",
+        type=Path,
+        default=data.repo_root
+        / "_results"
+        / "data"
+        / "pubmed_open_access_files_compressed",
+        help="Folder containing compressed PubMed Open Access archives.",
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=Path,
+        default=data.repo_root / "_results" / "data" / "pmc_captions.csv",
+        help="Path to write the CSV output.",
+    )
+    parser.add_argument(
+        "--parsed-jsonl",
+        type=Path,
+        default=data.repo_root / "_results" / "data" / "pubmed_parsed_data.json",
+        help="Path to write/read parsed PubMed JSONL data.",
+    )
+    parser.add_argument(
+        "--append",
+        action="store_true",
+        help="Append to the output CSV instead of overwriting.",
+    )
+    parser.add_argument(
+        "--decompress",
+        action="store_true",
+        help="Decompress the PubMed Open Access archives before parsing.",
+    )
+    parser.add_argument(
+        "--skip-pubmed-parser",
+        action="store_true",
+        help=(
+            "Skip parsing with pubmed_parser and use the existing JSONL data "
+            "instead."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    if not args.skip_pubmed_parser:
+        if args.decompress:
+            data.decompress_pubmed_files(
+                input_folder_path=args.compressed_folder,
+                output_folder_path=args.decompressed_folder,
+            )
+
+        data.generate_pmc15_pipeline_outputs(
+            decompressed_folder=args.decompressed_folder,
+            output_file_path=args.parsed_jsonl,
+        )
+    elif not args.parsed_jsonl.exists():
+        raise FileNotFoundError(
+            "Parsed JSONL file not found. Either run without "
+            "--skip-pubmed-parser or provide an existing --parsed-jsonl path."
+        )
+
+    articles = _load_parsed_articles(args.parsed_jsonl)
+    _export_to_csv(articles, args.output_csv, args.append)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_keyword_caption_export.py
+++ b/run_keyword_caption_export.py
@@ -123,6 +123,36 @@ def _iter_parsed_articles_from_nxml(decompressed_folder: Path) -> list[dict]:
     return articles
 
 
+def _maybe_decompress(
+    *,
+    compressed_folder: Path,
+    decompressed_folder: Path,
+    decompress: bool,
+) -> None:
+    if decompress:
+        data.decompress_pubmed_files(
+            input_folder_path=compressed_folder,
+            output_folder_path=decompressed_folder,
+        )
+        return
+
+    if decompressed_folder.exists() and any(
+        decompressed_folder.rglob("*.nxml")
+    ):
+        return
+
+    if not compressed_folder.exists():
+        raise FileNotFoundError(
+            "Compressed folder not found. Provide --compressed-folder or set "
+            "--decompressed-folder to an extracted directory."
+        )
+
+    data.decompress_pubmed_files(
+        input_folder_path=compressed_folder,
+        output_folder_path=decompressed_folder,
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Export PubMed figure captions to CSV."
@@ -186,11 +216,11 @@ def main() -> None:
         )
 
     if not args.skip_pubmed_parser and not args.no_json:
-        if args.decompress:
-            data.decompress_pubmed_files(
-                input_folder_path=args.compressed_folder,
-                output_folder_path=args.decompressed_folder,
-            )
+        _maybe_decompress(
+            compressed_folder=args.compressed_folder,
+            decompressed_folder=args.decompressed_folder,
+            decompress=args.decompress,
+        )
 
         data.generate_pmc15_pipeline_outputs(
             decompressed_folder=args.decompressed_folder,
@@ -203,11 +233,11 @@ def main() -> None:
         )
 
     if args.no_json:
-        if args.decompress:
-            data.decompress_pubmed_files(
-                input_folder_path=args.compressed_folder,
-                output_folder_path=args.decompressed_folder,
-            )
+        _maybe_decompress(
+            compressed_folder=args.compressed_folder,
+            decompressed_folder=args.decompressed_folder,
+            decompress=args.decompress,
+        )
         if not args.decompressed_folder.exists():
             raise FileNotFoundError(
                 "Decompressed folder not found. Provide --decompressed-folder "


### PR DESCRIPTION
### Motivation
- Provide a simple CLI to export figure metadata and captions from PubMed Open Access data into a CSV for downstream processing and analysis.
- Allow reuse of existing parsed JSONL data with a `--skip-pubmed-parser` flag and optionally decompress archives and re-run the parser when needed.

### Description
- Add `run_keyword_caption_export.py` which provides `_load_parsed_articles`, `_export_to_csv`, and a `main` function driven by `argparse` to control behavior.
- The script calls `data.decompress_pubmed_files` and `data.generate_pmc15_pipeline_outputs` when parsing is requested, and reads existing parsed JSONL via `--parsed-jsonl` when `--skip-pubmed-parser` is used.
- CSV output supports `--append` mode and writes rows with the fields `pmid`, `pmc`, `fig_id`, `fig_label`, `fig_caption`, `graphic_ref`, and `pair_id`, and uses sensible defaults based on `data.repo_root`.
- Includes header handling so appends do not duplicate headers and creates missing parent directories for the CSV output.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969f742a9608327944d93645a8b935f)